### PR TITLE
try netlify preview for website changes

### DIFF
--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -1,6 +1,5 @@
 name: NetlifyPreview
-on:
-  pull_request_target:
+on: workflow_dispatch
 
 jobs:
   add-preview:

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -1,0 +1,35 @@
+name: NetlifyPreview
+on:
+  pull_request_target:
+
+jobs:
+  add-preview:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout PR
+      uses: actions/checkout@v2
+
+    - name: Pull SnowEX Docker Image
+      run: |
+        docker pull uwhackweek/snowex:latest
+        docker images
+
+    - name: Build JupyterBook
+      run: |
+        docker run -u root -v ${{ github.workspace }}:/home/jovyan:rw uwhackweek/snowex:latest jb build book
+
+    - name: Deploy Website Preview
+      uses: nwtgck/actions-netlify@v1.1
+      with:
+        publish-dir: './book/_build/html'
+        production-branch: main
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        deploy-message: "Deploy from GitHub Actions"
+        enable-commit-comment: false
+        enable-pull-request-comment: true
+        overwrites-pull-request-comment: true
+        alias: deploy-preview-${{ github.event.number }}
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      timeout-minutes: 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,3 +27,19 @@ jobs:
     - name: Check External Links
       run: |
         docker run -u root -v ${{ github.workspace }}:/home/jovyan:rw uwhackweek/snowex:latest jb build book --builder linkcheck
+
+    - name: Deploy Website Preview
+      uses: nwtgck/actions-netlify@v1.1
+      with:
+        publish-dir: './book/_build/html'
+        production-branch: main
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        deploy-message: "Deploy from GitHub Actions"
+        enable-commit-comment: false
+        enable-pull-request-comment: true
+        overwrites-pull-request-comment: true
+        alias: deploy-preview-${{ github.event.number }}
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      timeout-minutes: 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,19 +27,3 @@ jobs:
     - name: Check External Links
       run: |
         docker run -u root -v ${{ github.workspace }}:/home/jovyan:rw uwhackweek/snowex:latest jb build book --builder linkcheck
-
-    - name: Deploy Website Preview
-      uses: nwtgck/actions-netlify@v1.1
-      with:
-        publish-dir: './book/_build/html'
-        production-branch: main
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        deploy-message: "Deploy from GitHub Actions"
-        enable-commit-comment: false
-        enable-pull-request-comment: true
-        overwrites-pull-request-comment: true
-        alias: deploy-preview-${{ github.event.number }}
-      env:
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      timeout-minutes: 1


### PR DESCRIPTION
closes #5 . will have to see how this works and iterate a bit probably.

This is a bit tricky to setup because we want: 
1. anyone in the world to be able to update and improve this book
2. not compromise access tokens and follow security best practices

When using the standard fork and change github workflow , PRs from forks DO NOT have access to repository secrets and therefore can't run workflows that require them (such as a netlify workflow that needs access credentials). So I think the strategy should be that workflows requiring credentials (such as generating live website previews) should be triggered manually. the [`workflow_dispatch` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) can only be triggered by people with write permissions to the repository, for example organization 'Owners' or people on a team that has write permissions 

https://github.community/t/who-has-permission-to-workflow-dispatch/133981/4  

