### PR TITLE
fix website preview from PRs

### DIFF
--- a/.github/workflows/binder-badge.yml
+++ b/.github/workflows/binder-badge.yml
@@ -2,6 +2,10 @@ name: AddBinderBadge
 on:
   pull_request_target:
     types: [opened, reopened]
+    paths:
+      - 'book/**'
+      - '.github/workflows/binder-badge.yml'
+      - '.binder'
 jobs:
   add-badge:
     runs-on: ubuntu-latest

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -1,13 +1,19 @@
 name: NetlifyPreview
-on: pull_request
+
+on: pull_request_target
 
 jobs:
   add-preview:
-    environment: production
     runs-on: ubuntu-latest
+    # This workflow accesses secrets and checks out a PR, so only run if labelled
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+
     steps:
     - name: Checkout PR
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Pull SnowEX Docker Image
       run: |


### PR DESCRIPTION
After a few failed experiments (#10) and 3e19cc8a8d78dbbf4fbb0a2ab26960670ec6a234 , I came across this excellent blog post which explains strategies for accomplishing what we need to do with PRs from forks https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ 

Basically, a PR can come from anyone, and we don't want to compromise any secrets on github, so the strategy is to only run workflows that checkout changes from PRs if a repository owner has looked at the code and manually approved it. It seems the easiest way to accomplish this is by adding a 'preview' label to the PR