### PR TITLE
add AWS Role for executing jupyter book

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,9 +23,21 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker images
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+        role-to-assume: github-actions-role
+        role-duration-seconds: 900
+
     - name: Build JupyterBook
       run: |
-        docker run -u root -v ${{ github.workspace }}:/home/jovyan:rw $DOCKER_IMAGE jb build book
+        docker run -u root \
+        -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+        -v ${{ github.workspace }}:/home/jovyan:rw \
+        $DOCKER_IMAGE jb build book
 
     - name: Publish to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -25,10 +25,22 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker images
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+        role-to-assume: github-actions-role
+        role-duration-seconds: 900
+
     # NOTE: --warningiserror not used here, so that whatever does work is rendered
     - name: Build JupyterBook
       run: |
-        docker run -u root -v ${{ github.workspace }}:/home/jovyan:rw $DOCKER_IMAGE jb build book
+        docker run -u root \
+        -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+        -v ${{ github.workspace }}:/home/jovyan:rw \
+        $DOCKER_IMAGE jb build book
 
     - name: Deploy Website Preview
       uses: nwtgck/actions-netlify@v1.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,9 +29,21 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker images
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+        role-to-assume: github-actions-role
+        role-duration-seconds: 900
+
     - name: Build JupyterBook
       run: |
-        docker run -u root -v ${{ github.workspace }}:/home/jovyan:rw $DOCKER_IMAGE jb build book --warningiserror --keep-going
+        docker run -u root \
+        -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+        -v ${{ github.workspace }}:/home/jovyan:rw \
+        $DOCKER_IMAGE jb build book --warningiserror --keep-going
 
     - name: Save Build
       if: ${{ always() }}


### PR DESCRIPTION
I'm not 100% sure this will work, but should fix https://github.com/snowex-hackweek/website/issues/71 . Specifically, the LIS modeling tutorial needs access to a private bucket on S3, so we need to pass AWS credentials to github actions. 

In general this should be helpful as the book building (executing .ipynb tutorials) executes with the same permissions as a user of the hackweek jupyterhub. 

Could be worth investigating an alternative configuration in the future where the book building executes on the hub cluster itself instead of a github actions runner...