### PR TITLE
fix netrc permissions via docker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,9 +38,11 @@ jobs:
         echo "machine urs.earthdata.nasa.gov login ${{ secrets.EARTHDATA_LOGIN }} password ${{ secrets.EARTHDATA_PASSWORD }}" > .netrc
         chmod 0600 .netrc
 
+    # NOTE github actions id: uid=1001(runner) gid=121(docker) groups=121(docker),4(adm),101(systemd-journal)
+    # Docker volume mount requires uid matching host, so we change from default (jovyan uid=1000)
     - name: Build JupyterBook
       run: |
-        docker run -u root \
+        docker run -u 1001 \
         -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
         -v ${{ github.workspace }}:/home/jovyan:rw \
         $DOCKER_IMAGE jb build book

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -41,9 +41,11 @@ jobs:
         chmod 0600 .netrc
 
     # NOTE: --warningiserror not used here, so that whatever does work is rendered
+    # NOTE github actions id: uid=1001(runner) gid=121(docker) groups=121(docker),4(adm),101(systemd-journal)
+    # Docker volume mount requires uid matching host, so we change from default (jovyan uid=1000)
     - name: Build JupyterBook
       run: |
-        docker run -u root \
+        docker run -u 1001 \
         -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
         -v ${{ github.workspace }}:/home/jovyan:rw \
         $DOCKER_IMAGE jb build book

--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -36,6 +36,8 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker images
 
+    # NOTE github actions id: uid=1001(runner) gid=121(docker) groups=121(docker),4(adm),101(systemd-journal)
+    # Docker volume mount requires uid matching host, so we change from default (jovyan uid=1000)
     - name: Check External Links
       run: |
-        docker run -u root -v ${{ github.workspace }}:/home/jovyan:rw $DOCKER_IMAGE jb build book --builder linkcheck
+        docker run -u 1001 -v ${{ github.workspace }}:/home/jovyan:rw $DOCKER_IMAGE jb build book --builder linkcheck

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,9 +45,11 @@ jobs:
         echo "machine urs.earthdata.nasa.gov login ${{ secrets.EARTHDATA_LOGIN }} password ${{ secrets.EARTHDATA_PASSWORD }}" > .netrc
         chmod 0600 .netrc
 
+    # NOTE github actions id: uid=1001(runner) gid=121(docker) groups=121(docker),4(adm),101(systemd-journal)
+    # Docker volume mount requires uid matching host, so we change from default (jovyan uid=1000)
     - name: Build JupyterBook
       run: |
-        docker run -u root \
+        docker run -u 1001 \
         -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
         -v ${{ github.workspace }}:/home/jovyan:rw \
         $DOCKER_IMAGE jb build book --warningiserror --keep-going


### PR DESCRIPTION
If we don't do this, code reading a netrc in a jupyter notebook won't work (as in #68)

```python
import netrc    
(ASF_USER, account, ASF_PASS) = netrc.netrc().authenticators("urs.earthdata.nasa.gov")
```

We end up with errors like this:
```
[0;31mNetrcParseError[0m: ~/.netrc file owner (uid 1001) does not match current user (root) (/home/jovyan/.netrc, line 1)
```