### PR TITLE
Adding file with links to SnowEx news and recordings of monthly meetings

### DIFF
--- a/book/SnowEx_News_and_MonthlyMeetings.md
+++ b/book/SnowEx_News_and_MonthlyMeetings.md
@@ -1,0 +1,9 @@
+# SnowEx_News_and_MonthlyMeetings
+
+```{SnowEx_News_and_MonthlyMeetings}
+[SnowEx_News_and_MonthlyMeetings](https://docs.google.com/document/d/1IIX-aPIU04kOgtz1v73JSDOtLlhoBDAovaahSvbVlwQ/edit?usp=sharing)
+  This Google Doc contains links to the media videos, articles and blogs about SnowEx, highlighting many different components and groups.  In addition, the links to the recordings from the SnowEx Community meetings are at the bottom of this file - many presentations have been given on the datasets collected and published at NSIDC.
+  
+To Do: This should be cleaned up and put in markdown, with links.  Adding the agenda to each community meeting link would help people navigate to datasets of interest.
+
+```

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -61,3 +61,4 @@
   chapters:
     - file: glossary
     - file: bibliography
+    - file: SnowEx_News_and_MonthlyMeetings

--- a/book/tutorials/sar/uavsar.ipynb
+++ b/book/tutorials/sar/uavsar.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "Intro slide deck: https://uavsar.jpl.nasa.gov/education/what-is-uavsar.html \n",
     "\n",
-    "*Tutorial author:  Jack Tarricone, University of Nevada Reno*"
+    "*Lead developer:  Jack Tarricone, University of Nevada Reno, Other developers: Franz Meyer, University of Alaska Fairbanks and HP Marshall, Boise State University*"
    ]
   },
   {


### PR DESCRIPTION
This is a start on having all the SnowEx news links in one place for reference, especially for people new to SnowEx.

Also, this file contains links to the recordings of the SnowEx Community meetings.

