### PR TITLE
save build on deploy, dont print cache

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -23,11 +23,6 @@ jobs:
         path: ./book/_build
         key: jupyterbook-4
 
-    - name: List Jupyter-Cache contents
-      run: |
-        pip install tabulate --no-deps
-        jcache cache list -p book/_build/.jupyter_cache
-
     - name: Pull Docker Image
       run: |
         docker pull $DOCKER_IMAGE

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,10 +25,11 @@ jobs:
         path: ./book/_build
         key: jupyterbook-4
 
-    - name: List Jupyter-Cache contents
-      run: |
-        pip install tabulate --no-deps
-        jcache cache list -p book/_build/.jupyter_cache
+    # NOTE: download build-artifact (_build) folder to inspect cache locally 
+    # - name: List Jupyter-Cache contents
+    #  run: |
+    #    pip install tabulate --no-deps
+    #    jcache cache list -p book/_build/.jupyter_cache
 
     - name: Pull Docker Image
       run: |
@@ -62,3 +63,10 @@ jobs:
         personal_token: ${{ secrets.GH_PAT }}
         publish_dir: book/_build/html
         publish_branch: gh-pages
+
+    - name: Save Build
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: book/_build/

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -27,11 +27,6 @@ jobs:
         path: ./book/_build
         key: jupyterbook-4
 
-    - name: List Jupyter-Cache contents
-      run: |
-        pip install tabulate --no-deps
-        jcache cache list -p book/_build/.jupyter_cache
-
     - name: Pull SnowEX Docker Image
       run: |
         docker pull $DOCKER_IMAGE

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,11 +32,6 @@ jobs:
         path: ./book/_build
         key: jupyterbook-4
 
-    - name: List Jupyter-Cache contents
-      run: |
-        pip install tabulate --no-deps
-        jcache cache list -p book/_build/.jupyter_cache
-
     - name: Pull Docker Image
       run: |
         docker pull $DOCKER_IMAGE

--- a/book/tutorials/nsidc-access/nsidc-data-access.ipynb
+++ b/book/tutorials/nsidc-access/nsidc-data-access.ipynb
@@ -11,7 +11,7 @@
     "Author: Amy Steiker, NSIDC DAAC, CIRES, University of Colorado\n",
     "\n",
     "\n",
-    "This tutorial provides a brief overview of the resources provided by the NASA National Snow and Ice Data Center Distributed Active Archive Center, or NSIDC DAAC, and demonstrates how to disscovery and access SnowEx data programmatically.  \n",
+    "This tutorial provides a brief overview of the resources provided by the NASA National Snow and Ice Data Center Distributed Active Archive Center, or NSIDC DAAC, and demonstrates how to discovery and access SnowEx data programmatically.  \n",
     "\n",
     "## Learning Objectives:\n",
     "\n",
@@ -511,8 +511,8 @@
     "    return  \n",
     "\n",
     "\n",
-    "# NOTE: uncomment the following command to run this API request:\n",
-    "#request_nsidc_data(api_request)"
+    "# NOTE: downloads ~ 200MB of CSV files\n",
+    "request_nsidc_data(api_request)"
    ]
   },
   {


### PR DESCRIPTION
followup to #130 

- added a manual github actions workflow to rebuild website without using cache
- added a cron github actions workflow that runs once a week so that the cache remains active
- nsidc data access notebook *should* now render