### PR TITLE
initial citation and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## ..
+- added CHANGELOG.md CITATION.cff (#154)
+- reorgainzed TOC and table of tutorials (#152)
+- hydroportal.cuahsi.org links now require https:// (#153) 
+- point tutorials accessing SnowEx database to `db.snowexdata.org` (#148)
+
+## 2021.07.23
+- Initial release, original SnowEx hackweek content 🎉
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,8 +18,8 @@ authors:
   given-names: Anthony
   orcid: "https://orcid.org/0000-0003-0429-6905"
   affiliation: University of Washington
-- family-names: Joachim
-  given-names: Meyer
+- family-names: Meyer
+  given-names: Joachim
   orcid: "https://orcid.org/0000-0002-1358-2244"
   affiliation: University of Utah
 - family-names: Setiawan
@@ -74,6 +74,7 @@ authors:
   affiliation: Boise State University
 - family-names: Webb
   given-names: Ryan
+  orcid: "https://orcid.org/0000-0002-1565-909X"
   affiliation: University of New Mexico
 - family-names: McGrath
   given-names: Dan
@@ -98,6 +99,7 @@ authors:
   affiliation: University of Washington
 - family-names: Webster
   given-names: Clare
+  orcid: "https://orcid.org/0000-0002-6386-6392"
   affiliation: SLF Switzerland
 - family-names: Smith
   given-names: Ben

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,124 @@
+cff-version: 1.2.0
+message: "If you use this book, please cite it as below."
+title: "SnowEx Hackweek JupyterBook Tutorials"
+version: 2021.07.23
+date-released: "2021-07-23"
+identifiers:
+- description: "collection of archived snapshots of all versions"
+  type: doi
+  value: TODO
+  license: MIT
+  repository-code: https://github.com/snowex-hackweek/website
+authors:
+- family-names: Henderson
+  given-names: Scott
+  orcid: "https://orcid.org/0000-0003-0624-4965"
+  affiliation: University of Washington
+- family-names: Arendt
+  given-names: Anthony
+  orcid: "https://orcid.org/0000-0003-0429-6905"
+  affiliation: University of Washington
+- family-names: Joachim
+  given-names: Meyer
+  orcid: "https://orcid.org/0000-0002-1358-2244"
+  affiliation: University of Utah
+- family-names: Setiawan
+  given-names: Landung
+  orcid: "https://orcid.org/0000-0002-1624-2667"
+  affiliation: University of Washington
+- family-names: Marshall
+  given-names: "Hans-Peter"
+  orcid: "https://orcid.org/0000-0002-4852-5637"
+  affiliation: Boise State University
+- family-names: Johnson
+  given-names: Micah
+  orcid: "https://orcid.org/0000-0003-4029-8545"
+  affiliation: Boise State University
+- family-names: Mason
+  given-names: Megan
+  affiliation: Boise State University
+- family-names: Lundquist
+  given-names: Jessica
+  orcid: "https://orcid.org/0000-0003-2193-5633"
+  affiliation: University of Washington
+- family-names: Pestana
+  given-names: Steven
+  orcid: "https://orcid.org/0000-0003-3360-0996"
+  affiliation: University of Washington
+- family-names: Shean
+  given-names: David
+  orcid: "https://orcid.org/0000-0003-3840-3860"
+  affiliation: University of Washington
+- family-names: Durand
+  given-names: Michael
+  affiliation: Ohio State University
+- family-names: Wrzesien
+  given-names: Melissa
+  orcid: "https://orcid.org/0000-0003-4958-9234"
+  affiliation: NASA Goddard Space Flight Center
+- family-names: McAndrew
+  given-names: Brendan
+  affiliation: NASA Goddard Space Flight Center
+- family-names: Ofekeze
+  given-names: Evi
+  affiliation: Boise State University
+- family-names: Alabi
+  given-names: Ibrahim
+  affiliation: Boise State University
+- family-names: Tarricone
+  given-names: Jack
+  affiliation: University of Nevada, Reno
+- family-names: Meehan
+  given-names: Tate
+  orcid: "https://orcid.org/0000-0002-3176-9248"
+  affiliation: Boise State University
+- family-names: Webb
+  given-names: Ryan
+  affiliation: University of New Mexico
+- family-names: McGrath
+  given-names: Dan
+  orcid: "https://orcid.org/0000-0002-9462-6842"
+  affiliation: Colorado State University
+- family-names: Boyd
+  given-names: Dylan
+  orcid: "https://orcid.org/0000-0002-1110-2454"
+  affiliation: Mississippi State University
+- family-names: Osmanoglu
+  given-names: Batuhan
+  affiliation: NASA Goddard Space Flight Center
+- family-names: Hudson
+  given-names: Dere
+  affiliation: NASA Goddard Space Flight Center
+- family-names: Breen
+  given-names: Katie
+  affiliation: University of Washington
+- family-names: Lumbrazo
+  given-names: Cassie
+  orcid: "https://orcid.org/0000-0003-1656-9771"
+  affiliation: University of Washington
+- family-names: Webster
+  given-names: Clare
+  affiliation: SLF Switzerland
+- family-names: Smith
+  given-names: Ben
+  affiliation: University of Washington
+- family-names: Scheick
+  given-names: Jessica
+  affiliation: University of New Hampshire
+- family-names: Vuyovich
+  given-names: Carrie
+  affiliation: NASA Goddard Space Flight Center
+- family-names: Steiker
+  given-names: Amy
+  orcid: "https://orcid.org/0000-0002-3039-0260"
+  affiliation: NASA NSIDC
+- family-names: Haley
+  given-names: Charley
+  affiliation: University of Washington
+- family-names: Koh
+  given-names: Jane
+  affiliation: University of Washington
+keywords:
+- NASA
+- SnowEx
+- Python

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -52,6 +52,7 @@ authors:
 - family-names: Durand
   given-names: Michael
   affiliation: Ohio State University
+  orcid: "https://orcid.org/0000-0003-2682-6196"
 - family-names: Wrzesien
   given-names: Melissa
   orcid: "https://orcid.org/0000-0003-4958-9234"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -110,6 +110,14 @@ authors:
 - family-names: Vuyovich
   given-names: Carrie
   affiliation: NASA Goddard Space Flight Center
+- family-names: Cristea
+  given-names: Nicoleta
+  orcid: "https://orcid.org/0000-0002-9091-0280"
+  affiliation: University of Washington
+- family-names: Alterman
+  given-names: Naomi
+  orcid: "https://orcid.org/0000-0003-0392-3890"
+  affiliation: University of Washington
 - family-names: Steiker
   given-names: Amy
   orcid: "https://orcid.org/0000-0002-3039-0260"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -108,6 +108,7 @@ authors:
 - family-names: Scheick
   given-names: Jessica
   affiliation: University of New Hampshire
+  orcid: "https://orcid.org/0000-0002-3421-4459"
 - family-names: Vuyovich
   given-names: Carrie
   affiliation: NASA Goddard Space Flight Center


### PR DESCRIPTION
Addresses #15 and #151 to add [GitHub Citation.cff](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files). More detail on the fields you can have in citation.cff are here https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md

After merging this we'll create a release linked to a zenodo DOI and then add the DOI to citation.cff 

This does not address the tutorial data reproducibility discussed in #151, but at least will give us a citation for the jupyterbook website. 