### PR TITLE
Replace s3://snowex-data from tutorials with zenodo dataset

### DIFF
--- a/book/tutorials/camera-traps-tutorial/timelapse-camera-tutorial.ipynb
+++ b/book/tutorials/camera-traps-tutorial/timelapse-camera-tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "appreciated-seller",
+   "id": "overall-density",
    "metadata": {},
    "source": [
     "# Time-lapse Cameras and Snow Applications\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sorted-princeton",
+   "id": "civic-crest",
    "metadata": {},
    "source": [
     "## Time-lapse Cameras on Grand Mesa during SnowEx Field Campaigns\n",
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "foster-adams",
+   "id": "threaded-accounting",
    "metadata": {},
    "source": [
     "### All the time-lapse camera sites from SnowEx 2017 and 2020 plotted together on Grand Mesa. \n",
@@ -65,18 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "legitimate-phase",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Might need to reinstall folium to the JupyterHub each time you restart, unless it's added to the full environment. If so, use the following command line...\n",
-    "!pip install folium==0.12.1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "paperback-petroleum",
+   "id": "prospective-terminal",
    "metadata": {
     "tags": [
      "hide-input"
@@ -84,9 +73,6 @@
    },
    "outputs": [],
    "source": [
-    "# Hide the code block\n",
-    "{\"tags\": [\"hide-input\",]} # trying to prevent this code block from showing, code here: https://myst-nb.readthedocs.io/en/latest/use/hiding.html\n",
-    "\n",
     "# Import the mapping package\n",
     "import folium # folium interactive notebook plotting: quick start guide here: https://python-visualization.github.io/folium/quickstart.html\n",
     "\n",
@@ -173,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "delayed-philosophy",
+   "id": "binary-thong",
    "metadata": {},
    "source": [
     "* $\\color{red}{\\text{2017 locations are in red}}$\n",
@@ -182,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ultimate-digest",
+   "id": "textile-australian",
    "metadata": {},
    "source": [
     "### An automated way of viewing and mapping time-lapse photos"
@@ -190,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "rapid-office",
+   "id": "polyphonic-passage",
    "metadata": {},
    "source": [
     "**First, import all the packages we'll need for this tutorial**"
@@ -199,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "leading-mumbai",
+   "id": "laden-weather",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dominant-interference",
+   "id": "ready-monitor",
    "metadata": {},
    "source": [
     "**We will map 2020 time-lapse camera locations on the Grand Mesa with the 2020 snow pits for reference.** \n",
@@ -247,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "static-bangkok",
+   "id": "nasty-flush",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "external-skating",
+   "id": "creative-bowling",
    "metadata": {},
    "source": [
     "**Pull out the columns of interest to make it easier to visualize**\n",
@@ -282,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "coordinated-garage",
+   "id": "nearby-benchmark",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "early-starter",
+   "id": "nervous-compression",
    "metadata": {},
    "source": [
     "**Grab all the unique geometry objects (i.e., locations)**"
@@ -300,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fifteen-economy",
+   "id": "sitting-program",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "capital-warrior",
+   "id": "sealed-luther",
    "metadata": {},
    "source": [
     "**And, print out how many of each we found** "
@@ -320,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "protective-progress",
+   "id": "toxic-proceeding",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "representative-scene",
+   "id": "environmental-cookie",
    "metadata": {},
    "source": [
     "#### Plot the camera locations, using snow pit locations for reference."
@@ -342,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sensitive-action",
+   "id": "martial-mason",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "surgical-polyester",
+   "id": "remarkable-jamaica",
    "metadata": {},
    "source": [
     "- What do you notice? Is there overlap between the snow pit and camera trap locations?"
@@ -374,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "blocked-surveillance",
+   "id": "completed-shock",
    "metadata": {},
    "source": [
     "### Viewing the time-lapse photos\n",
@@ -385,30 +371,49 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accessory-slovenia",
+   "id": "bibliographic-pendant",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!aws --no-progress s3 cp s3://snowex-data/tutorial-data/camera-trap/WSCT0378.JPG /tmp/WSCT0378.JPG\n",
-    "!aws --no-progress s3 cp s3://snowex-data/tutorial-data/camera-trap/WSCT0101.JPG /tmp/WSCT0101.JPG\n",
-    "!aws --no-progress s3 cp s3://snowex-data/tutorial-data/camera-trap/WSCT0742.JPG /tmp/WSCT0742.JPG"
+    "#%%bash \n",
+    "\n",
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "according-peoples",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TUTORIAL_DATA = '/tmp/tutorial-data/camera-trap'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "continental-checklist",
+   "id": "charming-heritage",
    "metadata": {},
    "source": [
     ":::{admonition} Important Note :class: hint\n",
     "\n",
-    "Remember, this is a subset of sample images from SnowEx 2020 temporarily stored on SnowEx's Amazon Web Service (AWS) server. The final images for SnowEx 2017 and 2020 will all be available on NSIDC. \n",
+    "Remember, this is a subset of sample images from SnowEx 2020 temporarily stored for SnowEx Hackweek The final images for SnowEx 2017 and 2020 will all be available on NSIDC. \n",
     "\n",
     ":::"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "spare-celtic",
+   "id": "finished-coffee",
    "metadata": {},
    "source": [
     "**Now display an example time-lapse image inside the notebook**\n",
@@ -420,27 +425,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "close-characteristic",
+   "id": "expensive-overhead",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Pull and display the images from Oct, Jan, and May \n",
-    "october_img = Image(filename='/tmp/WSCT0101.JPG', width=500, height=350)\n",
+    "october_img = Image(filename=f'{TUTORIAL_DATA}/WSCT0101.JPG', width=500, height=350)\n",
     "print('Site E9B in October')\n",
     "display(october_img)\n",
     "\n",
-    "january_img = Image(filename='/tmp/WSCT0378.JPG', width=500, height=350)\n",
+    "january_img = Image(filename=f'{TUTORIAL_DATA}/WSCT0378.JPG', width=500, height=350)\n",
     "print('Site E9B in January')\n",
     "display(january_img)\n",
     "\n",
-    "may_img = Image(filename='/tmp/WSCT0742.JPG', width=500, height=350)\n",
+    "may_img = Image(filename=f'{TUTORIAL_DATA}/WSCT0742.JPG', width=500, height=350)\n",
     "print('Site E9B in May')\n",
     "display(may_img)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "widespread-cradle",
+   "id": "hourly-johnson",
    "metadata": {},
    "source": [
     "- What do you notice? Is this an open or closed canopy site? \n",
@@ -450,7 +455,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "proved-budget",
+   "id": "viral-drink",
    "metadata": {},
    "source": [
     "## Time-lapse Camera Applications\n",
@@ -465,18 +470,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alert-camera",
+   "id": "electronic-prospect",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!aws --no-progress s3 cp s3://snowex-data/tutorial-data/camera-trap/Picture1.png /tmp/camera-trap/Picture1.png\n",
-    "pil_img = Image(filename='/tmp/camera-trap/Picture1.png', width=800, height=500)\n",
+    "pil_img = Image(filename=f'{TUTORIAL_DATA}/Picture1.png', width=800, height=500)\n",
     "display(pil_img)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "computational-inclusion",
+   "id": "alone-jacket",
    "metadata": {},
    "source": [
     "**Figure 1: Equation to extract snow depth from camera images. For each image, take the difference in pixels between the length of a snow-free stake and the length of the stake and multiply by length(cm)/pixel. The ratio can be found by dividing the full length of the stake (304.8 cm) by the length of a snow-free stake in pixels.**\n",
@@ -486,7 +490,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "increased-electron",
+   "id": "accessory-coordinator",
    "metadata": {},
    "source": [
     "#### **Plot the Snow Depth created from a Vegetated and an Open Camera Site**\n",
@@ -497,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ranging-avatar",
+   "id": "dress-reset",
    "metadata": {},
    "source": [
     "#### Let's start by visualizing where these two camera sites are on Grand Mesa\n",
@@ -510,7 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "proved-cameroon",
+   "id": "cooperative-atlanta",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bacterial-universal",
+   "id": "regulated-pride",
    "metadata": {},
    "source": [
     "**View associated time-lapse images using the AWS server.**"
@@ -532,32 +536,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "closed-sessions",
+   "id": "every-bristol",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!aws --no-progress s3 cp s3://snowex-data/tutorial-data/camera-trap/W1A/WSCT0013.JPG /tmp/camera-trap/W1A/WSCT0013.JPG\n",
-    "!aws --no-progress s3 cp s3://snowex-data/tutorial-data/camera-trap/W9A/WSCT0009.JPG /tmp/camera-trap/W9A/WSCT0009.JPG"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "silver-stockholm",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "open_canopy = Image(filename='/tmp/camera-trap/W1A/WSCT0013.JPG',  width=500, height=350)\n",
+    "open_canopy = Image(filename=f'{TUTORIAL_DATA}/W1A/WSCT0013.JPG',  width=500, height=350)\n",
     "print('Below is the open site, W1A')\n",
     "display(open_canopy)\n",
-    "closed_canopy = Image(filename='/tmp/camera-trap/W9A/WSCT0009.JPG',  width=500, height=350)\n",
+    "closed_canopy = Image(filename=f'{TUTORIAL_DATA}/W9A/WSCT0009.JPG',  width=500, height=350)\n",
     "print('Below is the forested site, W9A')\n",
     "display(closed_canopy)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "domestic-snowboard",
+   "id": "thrown-return",
    "metadata": {},
    "source": [
     "**Grab the site data for both sites from the database**"
@@ -566,7 +559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "color-perfume",
+   "id": "neural-royalty",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "administrative-conflict",
+   "id": "fourth-lyric",
    "metadata": {},
    "source": [
     "**Plot the snow depth from open and forested time-lapse camera sites together**"
@@ -596,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "egyptian-diameter",
+   "id": "saving-solid",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confidential-separation",
+   "id": "expired-entry",
    "metadata": {},
    "source": [
     "Previous forest-snow research, such as *Dickerson-Lange et al. (2017)*, have used similar analysis to determine the snow disappearance timing in forested regions of the Pacific Northwest. Further research could use this dataset to explore the following, \n",
@@ -628,7 +621,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "prerequisite-comparative",
+   "id": "unlike-injury",
    "metadata": {},
    "source": [
     "### 2. Citizen Science Snow Classifications\n",
@@ -640,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "emotional-police",
+   "id": "special-sandwich",
    "metadata": {},
    "source": [
     ":::{admonition} Potential Project Ideas\n",
@@ -670,7 +663,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "figured-system",
+   "id": "excessive-redhead",
    "metadata": {},
    "source": [
     "### **Thanks for attending this tutorial. We look forward to see what you will find in these datasets!**\n",

--- a/book/tutorials/camera-traps-tutorial/timelapse-camera-tutorial.ipynb
+++ b/book/tutorials/camera-traps-tutorial/timelapse-camera-tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "overall-density",
+   "id": "authentic-device",
    "metadata": {},
    "source": [
     "# Time-lapse Cameras and Snow Applications\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "civic-crest",
+   "id": "awful-teens",
    "metadata": {},
    "source": [
     "## Time-lapse Cameras on Grand Mesa during SnowEx Field Campaigns\n",
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "threaded-accounting",
+   "id": "alleged-endorsement",
    "metadata": {},
    "source": [
     "### All the time-lapse camera sites from SnowEx 2017 and 2020 plotted together on Grand Mesa. \n",
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "prospective-terminal",
+   "id": "worthy-sympathy",
    "metadata": {
     "tags": [
      "hide-input"
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "binary-thong",
+   "id": "loose-dodge",
    "metadata": {},
    "source": [
     "* $\\color{red}{\\text{2017 locations are in red}}$\n",
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "textile-australian",
+   "id": "stuffed-edwards",
    "metadata": {},
    "source": [
     "### An automated way of viewing and mapping time-lapse photos"
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "polyphonic-passage",
+   "id": "subject-bahamas",
    "metadata": {},
    "source": [
     "**First, import all the packages we'll need for this tutorial**"
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "laden-weather",
+   "id": "ahead-watch",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ready-monitor",
+   "id": "linear-suicide",
    "metadata": {},
    "source": [
     "**We will map 2020 time-lapse camera locations on the Grand Mesa with the 2020 snow pits for reference.** \n",
@@ -233,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nasty-flush",
+   "id": "closed-appreciation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,12 +247,12 @@
     "\n",
     "# Convert it to a geopandas df and visualize the dataframe\n",
     "camera_depths = query_to_geopandas(qry, engine)\n",
-    "print(camera_depths.head())"
+    "camera_depths.head()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "creative-bowling",
+   "id": "married-milwaukee",
    "metadata": {},
    "source": [
     "**Pull out the columns of interest to make it easier to visualize**\n",
@@ -268,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nearby-benchmark",
+   "id": "controlling-silence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nervous-compression",
+   "id": "legendary-penalty",
    "metadata": {},
    "source": [
     "**Grab all the unique geometry objects (i.e., locations)**"
@@ -286,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sitting-program",
+   "id": "christian-sierra",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sealed-luther",
+   "id": "checked-settlement",
    "metadata": {},
    "source": [
     "**And, print out how many of each we found** "
@@ -306,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "toxic-proceeding",
+   "id": "offshore-marsh",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "environmental-cookie",
+   "id": "modern-airport",
    "metadata": {},
    "source": [
     "#### Plot the camera locations, using snow pit locations for reference."
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "martial-mason",
+   "id": "human-consideration",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "remarkable-jamaica",
+   "id": "first-light",
    "metadata": {},
    "source": [
     "- What do you notice? Is there overlap between the snow pit and camera trap locations?"
@@ -360,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "completed-shock",
+   "id": "previous-revolution",
    "metadata": {},
    "source": [
     "### Viewing the time-lapse photos\n",
@@ -371,28 +371,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bibliographic-pendant",
+   "id": "another-weekend",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%%bash \n",
+    "%%bash \n",
     "\n",
-    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
-    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "# Retrieve a copy of data files used in this tutorial from Zenodo.org:\n",
+    "# Re-running this cell will not re-download things if they already exist\n",
     "\n",
-    "#cd /tmp\n",
-    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
-    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
-    "#unzip -n tutorial-data.zip\n",
-    "\n",
-    "# temporary equivalent\n",
-    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+    "mkdir -p /tmp/tutorial-data\n",
+    "cd /tmp/tutorial-data\n",
+    "wget -q -nc -O data.zip https://zenodo.org/record/5504396/files/camera-trap.zip\n",
+    "unzip -q -n data.zip\n",
+    "rm data.zip"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "according-peoples",
+   "id": "written-submission",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "charming-heritage",
+   "id": "covered-eclipse",
    "metadata": {},
    "source": [
     ":::{admonition} Important Note :class: hint\n",
@@ -413,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "finished-coffee",
+   "id": "informative-albuquerque",
    "metadata": {},
    "source": [
     "**Now display an example time-lapse image inside the notebook**\n",
@@ -425,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "expensive-overhead",
+   "id": "local-rabbit",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +443,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hourly-johnson",
+   "id": "arabic-auckland",
    "metadata": {},
    "source": [
     "- What do you notice? Is this an open or closed canopy site? \n",
@@ -455,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "viral-drink",
+   "id": "northern-provider",
    "metadata": {},
    "source": [
     "## Time-lapse Camera Applications\n",
@@ -470,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "electronic-prospect",
+   "id": "reflected-greeting",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "alone-jacket",
+   "id": "overall-mayor",
    "metadata": {},
    "source": [
     "**Figure 1: Equation to extract snow depth from camera images. For each image, take the difference in pixels between the length of a snow-free stake and the length of the stake and multiply by length(cm)/pixel. The ratio can be found by dividing the full length of the stake (304.8 cm) by the length of a snow-free stake in pixels.**\n",
@@ -490,7 +488,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "accessory-coordinator",
+   "id": "tough-department",
    "metadata": {},
    "source": [
     "#### **Plot the Snow Depth created from a Vegetated and an Open Camera Site**\n",
@@ -501,7 +499,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dress-reset",
+   "id": "revised-walnut",
    "metadata": {},
    "source": [
     "#### Let's start by visualizing where these two camera sites are on Grand Mesa\n",
@@ -514,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cooperative-atlanta",
+   "id": "adequate-roller",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -527,7 +525,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "regulated-pride",
+   "id": "neural-universal",
    "metadata": {},
    "source": [
     "**View associated time-lapse images using the AWS server.**"
@@ -536,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "every-bristol",
+   "id": "religious-gamma",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "thrown-return",
+   "id": "ranging-referral",
    "metadata": {},
    "source": [
     "**Grab the site data for both sites from the database**"
@@ -559,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "neural-royalty",
+   "id": "portable-adelaide",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fourth-lyric",
+   "id": "completed-stock",
    "metadata": {},
    "source": [
     "**Plot the snow depth from open and forested time-lapse camera sites together**"
@@ -589,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "saving-solid",
+   "id": "matched-luxury",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +607,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "expired-entry",
+   "id": "metallic-coupon",
    "metadata": {},
    "source": [
     "Previous forest-snow research, such as *Dickerson-Lange et al. (2017)*, have used similar analysis to determine the snow disappearance timing in forested regions of the Pacific Northwest. Further research could use this dataset to explore the following, \n",
@@ -621,7 +619,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unlike-injury",
+   "id": "under-addition",
    "metadata": {},
    "source": [
     "### 2. Citizen Science Snow Classifications\n",
@@ -633,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "special-sandwich",
+   "id": "cellular-being",
    "metadata": {},
    "source": [
     ":::{admonition} Potential Project Ideas\n",
@@ -663,7 +661,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "excessive-redhead",
+   "id": "statistical-reviewer",
    "metadata": {},
    "source": [
     "### **Thanks for attending this tutorial. We look forward to see what you will find in these datasets!**\n",

--- a/book/tutorials/core-datasets/02_data-package.ipynb
+++ b/book/tutorials/core-datasets/02_data-package.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "preliminary-reach",
+   "id": "underlying-philadelphia",
    "metadata": {},
    "source": [
     "# Depths and Snow Pit Data Package Contents\n",
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "higher-credit",
+   "id": "reverse-reminder",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,15 +31,12 @@
     "#plotting imports\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.style.use(['seaborn-notebook'])\n",
-    "\n",
-    "# unique imports\n",
-    "import s3fs #access data from the AWS s3 bucket"
+    "plt.style.use(['seaborn-notebook'])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "authorized-messenger",
+   "id": "wicked-nudist",
    "metadata": {},
    "source": [
     "## Download snow depth data from NSIDC\n",
@@ -51,16 +48,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "necessary-atlas",
+   "id": "anonymous-currency",
    "metadata": {},
    "source": [
-    "## Method 1: Programmatically download snow depth data from NSIDC"
+    "os.chmod('/home/jovyan/.netrc', 0o600) #only necessary on snowex hackweek jupyterhub## Method 1: Programmatically download snow depth data from NSIDC"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "broadband-buffer",
+   "id": "numerical-dimension",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.chmod('/home/jovyan/.netrc', 0o600) #only necessary on snowex hackweek jupyterhub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "native-attitude",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "unauthorized-celebrity",
+   "id": "simplified-triumph",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,36 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sapphire-davis",
-   "metadata": {},
-   "source": [
-    "## Method 2: Access data from our shared resources server\n",
-    "Quick and easy access for hackweek or if you haven't gone through the steps to [configure programmatic access](https://snowex-hackweek.github.io/website/preliminary/earthdata.html#configure-programmatic-access-to-nasa-servers) to NASA servers yet. This pulls data from our AWS, S3 bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "intensive-safety",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Uses AWS credentials on machine\n",
-    "fs = s3fs.S3FileSystem() \n",
-    "\n",
-    "# which data bucket?\n",
-    "bucket = 'snowex-data'  \n",
-    "      \n",
-    "# contents inside /depths     \n",
-    "flist = fs.ls(f'{bucket}/tutorial-data/core-datasets/depths') \n",
-    "\n",
-    "# show list of files\n",
-    "print('File list is: ', flist)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "brazilian-nickel",
+   "id": "white-marks",
    "metadata": {},
    "source": [
     "### Read the Depth File"
@@ -122,14 +100,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adopted-acrylic",
+   "id": "disturbed-general",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# open depth data file, and create pandas dataframe\n",
-    "with fs.open(flist[0], 'rb') as f: \n",
-    "    \n",
-    "    df = pd.read_csv(f, sep=',', header=0, parse_dates=[[2,3]]) #parse the date[2] and time[3] columns such that they are read in as datetime dtypes\n",
+    "df = pd.read_csv('./data/depths/SnowEx2020_SnowDepths_COGM_alldepths_v01.csv', sep=',', header=0, parse_dates=[[2,3]]) #parse the date[2] and time[3] columns such that they are read in as datetime dtypes\n",
     "    \n",
     "print('file has been read, and is ready to use.')"
    ]
@@ -137,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "buried-march",
+   "id": "hungry-skirt",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "genuine-provision",
+   "id": "protecting-intermediate",
    "metadata": {},
    "source": [
     "### Prep for Data Analysis"
@@ -156,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "handy-museum",
+   "id": "dangerous-multiple",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "victorian-hundred",
+   "id": "suspected-topic",
    "metadata": {},
    "source": [
     "#### Use .groupby() to sort the data set"
@@ -188,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "collective-birthday",
+   "id": "interstate-electronics",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "brazilian-showcase",
+   "id": "proud-finnish",
    "metadata": {},
    "source": [
     "#### ***Your turn***"
@@ -210,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "departmental-bernard",
+   "id": "popular-florence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "second-wales",
+   "id": "relative-equipment",
    "metadata": {},
    "source": [
     "#### Find depths associated with a certain measurement tool"
@@ -234,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mediterranean-angle",
+   "id": "clear-ceremony",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "published-liability",
+   "id": "coastal-morrison",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "naval-parker",
+   "id": "narrative-reminder",
    "metadata": {},
    "source": [
     "#### ***Your turn***"
@@ -264,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "micro-patient",
+   "id": "blessed-calculation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "demanding-antarctica",
+   "id": "north-philippines",
    "metadata": {},
    "source": [
     "Let's make sure we all have the same pd.DataFrame() again"
@@ -285,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wanted-forwarding",
+   "id": "simple-payroll",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stopped-stick",
+   "id": "civic-tulsa",
    "metadata": {},
    "source": [
     "### Plotting"
@@ -305,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "entire-combine",
+   "id": "regulation-burner",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "representative-processing",
+   "id": "extended-party",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "analyzed-contents",
+   "id": "chief-wings",
    "metadata": {},
    "source": [
     "## Download snow pit data from NSIDC\n",
@@ -347,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "toxic-bible",
+   "id": "graduate-guinea",
    "metadata": {},
    "source": [
     "## Method 1: Programmatically download snow pit data from NSIDC"
@@ -356,65 +331,46 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "renewable-despite",
+   "id": "minute-speaking",
    "metadata": {},
    "outputs": [],
    "source": [
     "# load snow pit data\n",
-    "%run 'scripts/nsidc-download_SNEX20_GM_SP.001.py'\n",
-    "print('Grand Mesa 2020 Snow Pit data download complete')"
+    "#%run 'scripts/nsidc-download_SNEX20_GM_SP.001.py'\n",
+    "#print('Grand Mesa 2020 Snow Pit data download complete')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "broke-fever",
+   "metadata": {},
+   "source": [
+    "## Method 2: Access tutorial data from zenodo\n",
+    "\n",
+    "We've archived datasets used for 2021 Hackweek tutorials on [Zenodo](https://zenodo.org), to ensure that these tutorials can be run in the future. The following code pulls data from the Zenodo 'record' and unzips it:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bearing-jewel",
+   "id": "solid-publication",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# show filenames\n",
-    "path = Path('./data/pits/')\n",
+    "%%bash \n",
     "\n",
-    "for i, filename in enumerate(path.glob('*5N19*')):\n",
-    "    print(i, filename.name)"
+    "cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fundamental-rotation",
-   "metadata": {},
-   "source": [
-    "## Method 2: Access data from our shared resources server\n",
-    "Again, quick access for hackweek or if you haven't gone through the steps to [configure programmatic access](https://snowex-hackweek.github.io/website/preliminary/earthdata.html#configure-programmatic-access-to-nasa-servers) to NASA servers yet. This pulls data from our AWS, S3 bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "restricted-notification",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Uses AWS credentials on machine\n",
-    "fs = s3fs.S3FileSystem() \n",
-    "\n",
-    "# which data bucket?\n",
-    "bucket = 'snowex-data'  \n",
-    "      \n",
-    "# contents inside /pits     \n",
-    "flist = fs.ls(f'{bucket}/tutorial-data/core-datasets/pits/')\n",
-    "\n",
-    "# which files do we want?\n",
-    "suffix='.csv'\n",
-    "\n",
-    "# list comprehension to get .csv files (not .xlsx or .jpgs)\n",
-    "csv_files = [filename for filename in flist if filename.endswith(suffix)]\n",
-    "csv_files[:5]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "alien-orbit",
+   "id": "increasing-lodge",
    "metadata": {},
    "source": [
     "### Don't want to work with all the files? Method to filter files"
@@ -423,19 +379,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incoming-accuracy",
+   "id": "beginning-insured",
    "metadata": {},
    "outputs": [],
    "source": [
     "# what files would you like to find?\n",
     "parameter = 'temperature'\n",
     "pitID = '5N19'\n",
-    "date = '20200128'"
+    "date = '20200128'\n",
+    "\n",
+    "path = '/tmp/tutorial-data/core-datasets/pits/SnowEx20_SnowPits_GMIOP_{}_{}_{}_v01.csv'.format(date, pitID, parameter)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "orange-zealand",
+   "id": "humanitarian-lingerie",
    "metadata": {},
    "source": [
     "### Read the Pit Parameter File"
@@ -444,19 +402,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pretty-terrain",
+   "id": "nutritional-socket",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with fs.open('/snowex-data/tutorial-data/core-datasets/pits/SnowEx20_SnowPits_GMIOP_{}_{}_{}_v01.csv'.format(date, pitID, parameter), 'rb') as f:\n",
-    "    \n",
-    "    t = pd.read_csv(f, header=7)\n",
+    "t = pd.read_csv(path, header=7)\n",
     "t"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dental-summer",
+   "id": "leading-grill",
    "metadata": {},
    "source": [
     "### Plotting"
@@ -465,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "suitable-livestock",
+   "id": "fiscal-three",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,22 +437,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "rising-rendering",
+   "id": "realistic-closure",
    "metadata": {},
    "outputs": [],
    "source": [
     "# grab a different pit parameter file\n",
     "parameter = 'density'\n",
-    "with fs.open('/snowex-data/tutorial-data/core-datasets/pits/SnowEx20_SnowPits_GMIOP_{}_{}_{}_v01.csv'.format(date, pitID, parameter), 'rb') as f:\n",
-    "\n",
-    "    d = pd.read_csv(f, header=7)\n",
+    "path = '/tmp/tutorial-data/core-datasets/pits/SnowEx20_SnowPits_GMIOP_{}_{}_{}_v01.csv'.format(date, pitID, parameter)\n",
+    "d = pd.read_csv(path, header=7)\n",
     "d"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "described-sharp",
+   "id": "informational-maple",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "reverse-newfoundland",
+   "id": "republican-switzerland",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,14 +500,6 @@
     "ax.set_xlabel('Density kg/m3')\n",
     "ax.set_ylabel('Snow Depth (cm)')   "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "governmental-solid",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/book/tutorials/core-datasets/02_data-package.ipynb
+++ b/book/tutorials/core-datasets/02_data-package.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "underlying-philadelphia",
+   "id": "buried-rehabilitation",
    "metadata": {},
    "source": [
     "# Depths and Snow Pit Data Package Contents\n",
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "reverse-reminder",
+   "id": "religious-rwanda",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,45 @@
   },
   {
    "cell_type": "markdown",
-   "id": "wicked-nudist",
+   "id": "retired-sequence",
+   "metadata": {},
+   "source": [
+    "## Access tutorial data from Zenodo\n",
+    "\n",
+    "We've archived datasets used for 2021 Hackweek tutorials on [Zenodo](https://zenodo.org), to ensure that these tutorials can be run in the future. The following code pulls data from the Zenodo 'record' and unzips it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "solar-catalog",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash \n",
+    "\n",
+    "# Retrieve a copy of data files used in this tutorial from Zenodo.org:\n",
+    "# Re-running this cell will not re-download things if they already exist\n",
+    "\n",
+    "mkdir -p /tmp/tutorial-data\n",
+    "cd /tmp/tutorial-data\n",
+    "wget -q -nc -O data.zip https://zenodo.org/record/5504396/files/core-datasets.zip\n",
+    "rm data.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "african-blues",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TUTORIAL_DATA = '/tmp/tutorial-data/core-datasets'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "incorporated-accent",
    "metadata": {},
    "source": [
     "## Download snow depth data from NSIDC\n",
@@ -48,50 +86,49 @@
   },
   {
    "cell_type": "markdown",
-   "id": "anonymous-currency",
+   "id": "earned-vancouver",
    "metadata": {},
    "source": [
-    "os.chmod('/home/jovyan/.netrc', 0o600) #only necessary on snowex hackweek jupyterhub## Method 1: Programmatically download snow depth data from NSIDC"
+    "## Programmatically download snow depth data from NSIDC"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "numerical-dimension",
+   "id": "different-choice",
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.chmod('/home/jovyan/.netrc', 0o600) #only necessary on snowex hackweek jupyterhub"
+    "#os.chmod('/home/jovyan/.netrc', 0o600) #only necessary on snowex hackweek jupyterhub"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "native-attitude",
+   "id": "helpful-makeup",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%run './scripts/nsidc-download_SNEX20_SD.001.py' \n",
-    "print('Grand Mesa 2020 Snow Depth data download complete') "
+    "#%run './scripts/nsidc-download_SNEX20_SD.001.py' \n",
+    "#print('Grand Mesa 2020 Snow Depth data download complete') "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "simplified-triumph",
+   "id": "regular-innocent",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# show filename:\n",
-    "path = Path('./data/depths/')\n",
+    "#path = Path('./data/depths/')\n",
     "\n",
-    "for filename in path.glob('*.csv'):\n",
-    "    print(filename.name)"
+    "#for filename in path.glob('*.csv'):\n",
+    "#    print(filename.name)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "white-marks",
+   "id": "right-director",
    "metadata": {},
    "source": [
     "### Read the Depth File"
@@ -100,11 +137,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "disturbed-general",
+   "id": "opened-process",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_csv('./data/depths/SnowEx2020_SnowDepths_COGM_alldepths_v01.csv', sep=',', header=0, parse_dates=[[2,3]]) #parse the date[2] and time[3] columns such that they are read in as datetime dtypes\n",
+    "df = pd.read_csv(f'{TUTORIAL_DATA}/depths/SnowEx2020_SnowDepths_COGM_alldepths_v01.csv', sep=',', header=0, parse_dates=[[2,3]]) #parse the date[2] and time[3] columns such that they are read in as datetime dtypes\n",
     "    \n",
     "print('file has been read, and is ready to use.')"
    ]
@@ -112,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hungry-skirt",
+   "id": "premium-steal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "protecting-intermediate",
+   "id": "engaged-style",
    "metadata": {},
    "source": [
     "### Prep for Data Analysis"
@@ -131,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dangerous-multiple",
+   "id": "narrative-secretary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "suspected-topic",
+   "id": "raised-employer",
    "metadata": {},
    "source": [
     "#### Use .groupby() to sort the data set"
@@ -163,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "interstate-electronics",
+   "id": "supreme-mortality",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "proud-finnish",
+   "id": "mental-realtor",
    "metadata": {},
    "source": [
     "#### ***Your turn***"
@@ -185,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "popular-florence",
+   "id": "matched-married",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "relative-equipment",
+   "id": "sealed-columbia",
    "metadata": {},
    "source": [
     "#### Find depths associated with a certain measurement tool"
@@ -209,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "clear-ceremony",
+   "id": "driving-rough",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "coastal-morrison",
+   "id": "developmental-share",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "narrative-reminder",
+   "id": "innocent-distinction",
    "metadata": {},
    "source": [
     "#### ***Your turn***"
@@ -239,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "blessed-calculation",
+   "id": "freelance-anniversary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "north-philippines",
+   "id": "distinct-landscape",
    "metadata": {},
    "source": [
     "Let's make sure we all have the same pd.DataFrame() again"
@@ -260,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "simple-payroll",
+   "id": "civilian-inclusion",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "civic-tulsa",
+   "id": "leading-bulgaria",
    "metadata": {},
    "source": [
     "### Plotting"
@@ -280,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "regulation-burner",
+   "id": "trying-letters",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "extended-party",
+   "id": "searching-italian",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "chief-wings",
+   "id": "infrared-triumph",
    "metadata": {},
    "source": [
     "## Download snow pit data from NSIDC\n",
@@ -322,16 +359,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "graduate-guinea",
+   "id": "israeli-comedy",
    "metadata": {},
    "source": [
-    "## Method 1: Programmatically download snow pit data from NSIDC"
+    "## Programmatically download snow pit data from NSIDC"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "minute-speaking",
+   "id": "latter-stomach",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,35 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "broke-fever",
-   "metadata": {},
-   "source": [
-    "## Method 2: Access tutorial data from zenodo\n",
-    "\n",
-    "We've archived datasets used for 2021 Hackweek tutorials on [Zenodo](https://zenodo.org), to ensure that these tutorials can be run in the future. The following code pulls data from the Zenodo 'record' and unzips it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "solid-publication",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash \n",
-    "\n",
-    "cd /tmp\n",
-    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
-    "wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
-    "unzip -n tutorial-data.zip\n",
-    "\n",
-    "# temporary equivalent\n",
-    "#aws s3 sync s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "increasing-lodge",
+   "id": "manual-criticism",
    "metadata": {},
    "source": [
     "### Don't want to work with all the files? Method to filter files"
@@ -379,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "beginning-insured",
+   "id": "biblical-addition",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,12 +397,12 @@
     "pitID = '5N19'\n",
     "date = '20200128'\n",
     "\n",
-    "path = '/tmp/tutorial-data/core-datasets/pits/SnowEx20_SnowPits_GMIOP_{}_{}_{}_v01.csv'.format(date, pitID, parameter)"
+    "path = '{}/pits/SnowEx20_SnowPits_GMIOP_{}_{}_{}_v01.csv'.format(TUTORIAL_DATA, date, pitID, parameter)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "humanitarian-lingerie",
+   "id": "fiscal-sessions",
    "metadata": {},
    "source": [
     "### Read the Pit Parameter File"
@@ -402,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nutritional-socket",
+   "id": "electoral-supplement",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "leading-grill",
+   "id": "statewide-payment",
    "metadata": {},
    "source": [
     "### Plotting"
@@ -421,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fiscal-three",
+   "id": "stainless-advertising",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "realistic-closure",
+   "id": "brave-bridge",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "informational-maple",
+   "id": "sustainable-sheriff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "republican-switzerland",
+   "id": "graduate-positive",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/book/tutorials/core-datasets/03_practice-querying.ipynb
+++ b/book/tutorials/core-datasets/03_practice-querying.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "minimal-cuisine",
+   "id": "urban-steal",
    "metadata": {},
    "source": [
     "# Practice Querying the Snowexsql Database\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "turned-discussion",
+   "id": "floating-tennis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stable-reconstruction",
+   "id": "charitable-wages",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "arranged-checkout",
+   "id": "unlikely-dollar",
    "metadata": {},
    "source": [
     "## Snow Pit data are contained in the following data tables:  \n",
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "healthy-letters",
+   "id": "stupid-pathology",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "returning-locator",
+   "id": "unlikely-immune",
    "metadata": {},
    "source": [
     "#### 1a). Unsure of the flight date, but know which sensor you'd like to overlap with, here's how:"
@@ -90,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "french-doubt",
+   "id": "polished-boxing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "passing-virginia",
+   "id": "hundred-namibia",
    "metadata": {},
    "source": [
     "#### 1b). Want to select an exact flight date match? Here's how:"
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cooked-chassis",
+   "id": "liberal-consent",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "innovative-housing",
+   "id": "compact-printer",
    "metadata": {},
    "source": [
     "#### 1c). Want to select a range of dates near the flight date? Here's how:"
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "provincial-equipment",
+   "id": "varying-influence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "creative-railway",
+   "id": "located-redhead",
    "metadata": {},
    "source": [
     "#### 1d). Have a known date that you wish to select data for, here's how:"
@@ -206,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "marine-medline",
+   "id": "hundred-albania",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "excessive-fever",
+   "id": "emotional-america",
    "metadata": {},
    "source": [
     "### Nice work, almost done here!"
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "necessary-daisy",
+   "id": "criminal-insured",
    "metadata": {},
    "source": [
     "## Classify pit data based on the depth and vegetation matrix\n",
@@ -277,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nuclear-memphis",
+   "id": "ranging-performance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "premium-stylus",
+   "id": "chinese-likelihood",
    "metadata": {},
    "source": [
     "#### 2b). Distinguish pits by snow depth classes: \n",
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "corresponding-butterfly",
+   "id": "growing-glance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "searching-compiler",
+   "id": "floral-insight",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "directed-squad",
+   "id": "marked-government",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "generic-marketing",
+   "id": "proof-antarctica",
    "metadata": {},
    "source": [
     "### Plot"
@@ -423,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "funky-force",
+   "id": "emotional-mobile",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "married-enforcement",
+   "id": "smooth-infrastructure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "shaped-venue",
+   "id": "statutory-antique",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,21 +460,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "contemporary-madness",
+   "id": "stunning-angle",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Close your session to avoid hanging transactions\n",
     "session.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "abroad-hepatitis",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/book/tutorials/geospatial/SNOTEL_query.ipynb
+++ b/book/tutorials/geospatial/SNOTEL_query.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "certified-newspaper",
+   "id": "hired-infrastructure",
    "metadata": {},
    "source": [
     "# Dynamic Query of SNOTEL data\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "designed-rendering",
+   "id": "social-compression",
    "metadata": {},
    "source": [
     "## Introduction\n",
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "extraordinary-printer",
+   "id": "protecting-diary",
    "metadata": {},
    "source": [
     "## CUAHSI WOF server and automated Python data queries\n",
@@ -57,8 +57,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "directed-playlist",
+   "execution_count": null,
+   "id": "consistent-eleven",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "smart-capability",
+   "id": "monetary-politics",
    "metadata": {},
    "source": [
     "### Acronym soup\n",
@@ -95,8 +95,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "existing-delight",
+   "execution_count": null,
+   "id": "promotional-quantity",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "enabling-debut",
+   "id": "streaming-mercy",
    "metadata": {},
    "source": [
     "## Part 1: Spatial Query SNOTEL sites\n",
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "common-professional",
+   "id": "natural-union",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "caroline-adobe",
+   "id": "closing-format",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "artificial-manitoba",
+   "id": "knowing-marriage",
    "metadata": {},
    "source": [
     "### Store the dictionary as a Pandas DataFrame called `sites_df`\n",
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "modular-bhutan",
+   "id": "young-crazy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "accompanied-antique",
+   "id": "comprehensive-sugar",
    "metadata": {},
    "source": [
     "### Clean up the DataFrame and prepare Point geometry objects\n",
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "confidential-equivalent",
+   "id": "meaningful-pixel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "executive-chemical",
+   "id": "approximate-spare",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "robust-fifteen",
+   "id": "short-fiction",
    "metadata": {},
    "source": [
     "### Review output\n",
@@ -212,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "possible-receptor",
+   "id": "fresh-pierre",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "minus-thread",
+   "id": "basic-accused",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "defensive-advocacy",
+   "id": "advised-schema",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "allied-treatment",
+   "id": "outer-disorder",
    "metadata": {},
    "source": [
     "### Convert to a Geopandas GeoDataFrame\n",
@@ -252,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "grave-evening",
+   "id": "desperate-occurrence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "international-princess",
+   "id": "eight-advancement",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "explicit-elevation",
+   "id": "strong-cross",
    "metadata": {},
    "source": [
     "### Create a scatterplot showing elevation values for all sites"
@@ -281,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "median-fence",
+   "id": "international-employment",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "religious-titanium",
+   "id": "union-anger",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "double-trance",
+   "id": "serious-characteristic",
    "metadata": {},
    "source": [
     "### Exclude the Alaska (AK) points to isolate points over Western U.S.\n",
@@ -317,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acknowledged-serve",
+   "id": "trained-improvement",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +326,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "taken-pierce",
+   "id": "sustainable-quarterly",
    "metadata": {},
    "source": [
     "* Alternatively, can use a spatial filter (see GeoPandas `cx` indexer functionality for a bounding box)"
@@ -335,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "occupational-pontiac",
+   "id": "facial-geneva",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "demonstrated-retention",
+   "id": "demographic-hospital",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fuzzy-picture",
+   "id": "waiting-examination",
    "metadata": {},
    "source": [
     "### Update your scatterplot as sanity check\n",
@@ -365,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "painted-tender",
+   "id": "auburn-stomach",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "parental-reputation",
+   "id": "acute-healthcare",
    "metadata": {},
    "source": [
     "### Export SNOTEL site GeoDataFrame as a geojson\n",
@@ -387,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aquatic-batman",
+   "id": "limited-mumbai",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "polar-commons",
+   "id": "former-russian",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fourth-lodge",
+   "id": "least-newark",
    "metadata": {},
    "source": [
     "## Part 2: Spatial filter points by polygon"
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lovely-cabinet",
+   "id": "middle-norway",
    "metadata": {},
    "source": [
     "### Load Grand Mesa Polygon"
@@ -425,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "resistant-wealth",
+   "id": "bottom-classroom",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ethical-coach",
+   "id": "weekly-miami",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "chubby-calcium",
+   "id": "finite-stone",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adjustable-seafood",
+   "id": "central-lover",
    "metadata": {},
    "source": [
     "## A quick aside on `geometry` objects"
@@ -462,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "checked-technician",
+   "id": "seventh-greene",
    "metadata": {},
    "source": [
     "### Vector data contain `geometry` objects\n",
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "guilty-material",
+   "id": "great-trust",
    "metadata": {},
    "source": [
     "![Geometry types](https://datacarpentry.org/organization-geospatial/fig/dc-spatial-vector/pnt_line_poly.png)\n",
@@ -483,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "tropical-poetry",
+   "id": "rental-england",
    "metadata": {},
    "source": [
     "### Isolate Polygon geometry within GeoDataFrame"
@@ -492,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "welcome-steering",
+   "id": "exciting-camcorder",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,7 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cordless-scholarship",
+   "id": "alleged-frederick",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fixed-tuition",
+   "id": "usual-address",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nutritional-gather",
+   "id": "systematic-translation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "collected-walter",
+   "id": "theoretical-egypt",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lined-virtue",
+   "id": "loaded-challenge",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "buried-karaoke",
+   "id": "positive-purple",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "smoking-provincial",
+   "id": "public-wellington",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +572,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "earlier-accuracy",
+   "id": "downtown-priority",
    "metadata": {},
    "source": [
     "### Generate boolean index for points that intersect the polygon\n",
@@ -582,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "revolutionary-homework",
+   "id": "considered-herald",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "least-wednesday",
+   "id": "gorgeous-worry",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "crude-brick",
+   "id": "concrete-property",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "subsequent-eligibility",
+   "id": "latter-fifteen",
    "metadata": {},
    "source": [
     "### Use fancy indexing to isolate points and return new GeoDataFrame"
@@ -620,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "broke-console",
+   "id": "lyric-penalty",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incorrect-wisdom",
+   "id": "extraordinary-repeat",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "rotary-tribe",
+   "id": "embedded-upset",
    "metadata": {},
    "source": [
     "### Quick plot"
@@ -648,7 +648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "banner-background",
+   "id": "committed-ecuador",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pediatric-sociology",
+   "id": "unlimited-inspector",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cheap-arrow",
+   "id": "greatest-physiology",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +682,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "instrumental-timeline",
+   "id": "permanent-alexander",
    "metadata": {},
    "source": [
     "### Add a basemap\n",
@@ -696,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "gross-satisfaction",
+   "id": "applicable-plaintiff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "assured-nursery",
+   "id": "colonial-deputy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -716,7 +716,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "banner-stockholm",
+   "id": "latest-tsunami",
    "metadata": {},
    "source": [
     "## Part 3: Time series analysis for one station\n",
@@ -725,7 +725,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "green-commitment",
+   "id": "removable-creation",
    "metadata": {},
    "source": [
     "https://wcc.sc.egov.usda.gov/nwcc/site?sitenum=622&state=co"
@@ -734,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bibliographic-collector",
+   "id": "retained-southwest",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confidential-speaker",
+   "id": "hourly-watson",
    "metadata": {},
    "source": [
     "### Get available measurements for this site\n",
@@ -754,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "homeless-pakistan",
+   "id": "recovered-entry",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +763,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "arbitrary-jungle",
+   "id": "registered-queens",
    "metadata": {},
    "source": [
     "* _H = \"hourly\"\n",
@@ -773,7 +773,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "parliamentary-shopper",
+   "id": "reduced-thought",
    "metadata": {},
    "source": [
     "### Let's consider the 'SNOTEL:SNWD_D' variable (Daily Snow Depth)\n",
@@ -786,7 +786,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "offshore-chapter",
+   "id": "individual-college",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +799,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "senior-cleaning",
+   "id": "extensive-helen",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -812,7 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tested-funds",
+   "id": "unsigned-genome",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -821,7 +821,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "united-chart",
+   "id": "pursuant-friday",
    "metadata": {},
    "source": [
     "### Define a function to fetch data\n",
@@ -832,7 +832,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "searching-mounting",
+   "id": "enormous-clause",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -863,7 +863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "incoming-clearing",
+   "id": "local-construction",
    "metadata": {},
    "source": [
     "### Use this function to get the full 'SNOTEL:SNWD_D' record for one station\n",
@@ -874,7 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adjustable-haiti",
+   "id": "environmental-leonard",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "naked-advocate",
+   "id": "vital-opening",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -898,7 +898,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ethical-peripheral",
+   "id": "anticipated-mechanism",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +908,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "precise-explanation",
+   "id": "great-sharing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -919,7 +919,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "grateful-desert",
+   "id": "pleasant-belarus",
    "metadata": {},
    "source": [
     "### Create a quick plot to view the time series\n",
@@ -930,7 +930,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incredible-republic",
+   "id": "ongoing-livestock",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -939,7 +939,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bored-album",
+   "id": "relevant-conducting",
    "metadata": {},
    "source": [
     "### Compute the integer day of year (doy) and integer day of water year (dowy)\n",
@@ -954,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "varied-translator",
+   "id": "arabic-second",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -973,7 +973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hourly-charm",
+   "id": "talented-inventory",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "binding-wellington",
+   "id": "hollow-denial",
    "metadata": {},
    "source": [
     "### Compute statistics for each day of the water year, using values from all years\n",
@@ -993,7 +993,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "internal-brave",
+   "id": "relative-mustang",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,7 +1003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dressed-grammar",
+   "id": "joint-creator",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1013,7 +1013,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "marine-worthy",
+   "id": "funny-density",
    "metadata": {},
    "source": [
     "### Create a plot of these aggregated dowy values\n",
@@ -1023,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "invisible-fortune",
+   "id": "knowing-bishop",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1048,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "electronic-repository",
+   "id": "forty-effects",
    "metadata": {},
    "source": [
     "### Add the daily snow depth values for the current water year\n",
@@ -1061,7 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "funny-junior",
+   "id": "protected-diary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1073,7 +1073,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "engaged-papua",
+   "id": "checked-metabolism",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1084,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "driving-hearts",
+   "id": "italic-angle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1107,7 +1107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "challenging-award",
+   "id": "solar-swaziland",
    "metadata": {},
    "source": [
     "### What was the percentage of \"normal\" snow depth on April 1 of this year?\n",
@@ -1117,7 +1117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vanilla-memory",
+   "id": "institutional-velvet",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1127,7 +1127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "interracial-voluntary",
+   "id": "considerable-relations",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1138,7 +1138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "precise-battle",
+   "id": "chicken-meeting",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1148,7 +1148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "chinese-bishop",
+   "id": "breathing-transportation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1159,7 +1159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "burning-africa",
+   "id": "breeding-situation",
    "metadata": {},
    "source": [
     "### Index DataFrame by date or date range\n",
@@ -1169,7 +1169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "relevant-python",
+   "id": "directed-american",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1180,7 +1180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "exempt-nightlife",
+   "id": "parallel-there",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,7 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cathedral-aaron",
+   "id": "bored-weapon",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,7 +1201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "active-moscow",
+   "id": "square-edwards",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1210,7 +1210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "designing-village",
+   "id": "damaged-samuel",
    "metadata": {},
    "source": [
     "### Query multiple sites\n",
@@ -1220,7 +1220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hourly-tuesday",
+   "id": "minor-islam",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1238,7 +1238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "signed-foundation",
+   "id": "removed-proportion",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1248,7 +1248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ongoing-authority",
+   "id": "sorted-barrier",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1258,7 +1258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "united-shipping",
+   "id": "alike-request",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1269,7 +1269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "metallic-group",
+   "id": "funny-table",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "union-skating",
+   "id": "square-acquisition",
    "metadata": {},
    "source": [
     "### Scatterplot to compare corresponding values"
@@ -1287,7 +1287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mathematical-bowling",
+   "id": "antique-aside",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1297,7 +1297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "third-stick",
+   "id": "atlantic-reservation",
    "metadata": {},
    "source": [
     "### Determine Pearson's correlation coefficient for the two time series\n",
@@ -1309,7 +1309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "early-sixth",
+   "id": "mexican-strategy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1318,18 +1318,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "alpine-train",
+   "id": "native-disabled",
    "metadata": {},
    "source": [
     "Highly correlated snow depth records for these two sites!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "organizational-messenger",
-   "metadata": {},
-   "source": [
-    "## Summary"
    ]
   }
  ],

--- a/book/tutorials/geospatial/SNOTEL_query.ipynb
+++ b/book/tutorials/geospatial/SNOTEL_query.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "adverse-network",
+   "id": "certified-newspaper",
    "metadata": {},
    "source": [
     "# Dynamic Query of SNOTEL data\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "active-battle",
+   "id": "designed-rendering",
    "metadata": {},
    "source": [
     "## Introduction\n",
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "smart-reflection",
+   "id": "extraordinary-printer",
    "metadata": {},
    "source": [
     "## CUAHSI WOF server and automated Python data queries\n",
@@ -57,19 +57,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "sunset-means",
+   "execution_count": 1,
+   "id": "directed-playlist",
    "metadata": {},
    "outputs": [],
    "source": [
     "#This is the latest CUAHSI API endpoint\n",
-    "#http://his.cuahsi.org/wofws.html\n",
     "wsdlurl = 'https://hydroportal.cuahsi.org/Snotel/cuahsi_1_1.asmx?WSDL'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "governmental-cookie",
+   "id": "smart-capability",
    "metadata": {},
    "source": [
     "### Acronym soup\n",
@@ -85,7 +84,7 @@
     "\n",
     "There are a few packages out there that offer convenience functions to query the online SNOTEL databases and unpack the results.  \n",
     "* climata (https://pypi.org/project/climata/) - last commit Sept 2017 (not a good sign)\n",
-    "* ulmo (https://github.com/ulmo-dev/ulmo) - last commit Oct 2020 (will be superseded by a package called Quest, but still maintained by [Emilio Mayorga](https://apl.uw.edu/people/profile.php?last_name=Mayorga&first_name=Emilio) over at UW APL)\n",
+    "* ulmo (https://github.com/ulmo-dev/ulmo) - maintained by [Emilio Mayorga](https://apl.uw.edu/people/profile.php?last_name=Mayorga&first_name=Emilio) over at UW APL)\n",
     "\n",
     "You can also write your own queries using the Python `requests` module and some built-in XML parsing libraries.\n",
     "\n",
@@ -95,41 +94,9 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "clear-migration",
-   "metadata": {},
-   "source": [
-    "### Important ulmo installation note\n",
-    "\n",
-    "We're going to use the latest development version of ulmo, straight from the github source!  This is a good exercise, and will show you how to install a package directly from source code on github."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "noted-moore",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Install directly from github repo main branch\n",
-    "%pip install -q git+https://github.com/ulmo-dev/ulmo.git"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "defined-imaging",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Despite warning, shouldn't need to restart kernel if all goes well\n",
-    "import ulmo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "living-illness",
+   "execution_count": 3,
+   "id": "existing-delight",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,12 +107,13 @@
     "import pandas as pd\n",
     "import geopandas as gpd\n",
     "from shapely.geometry import Point\n",
-    "import contextily as ctx"
+    "import contextily as ctx\n",
+    "import ulmo"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "developmental-calendar",
+   "id": "enabling-debut",
    "metadata": {},
    "source": [
     "## Part 1: Spatial Query SNOTEL sites\n",
@@ -156,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "unnecessary-input",
+   "id": "common-professional",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "necessary-actress",
+   "id": "caroline-adobe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "suited-saudi",
+   "id": "artificial-manitoba",
    "metadata": {},
    "source": [
     "### Store the dictionary as a Pandas DataFrame called `sites_df`\n",
@@ -188,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "super-kernel",
+   "id": "modular-bhutan",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "athletic-camcorder",
+   "id": "accompanied-antique",
    "metadata": {},
    "source": [
     "### Clean up the DataFrame and prepare Point geometry objects\n",
@@ -211,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "distributed-physiology",
+   "id": "confidential-equivalent",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "skilled-tower",
+   "id": "executive-chemical",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "expensive-chick",
+   "id": "robust-fifteen",
    "metadata": {},
    "source": [
     "### Review output\n",
@@ -244,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "desperate-profit",
+   "id": "possible-receptor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adequate-payday",
+   "id": "minus-thread",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "coral-domestic",
+   "id": "defensive-advocacy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sporting-causing",
+   "id": "allied-treatment",
    "metadata": {},
    "source": [
     "### Convert to a Geopandas GeoDataFrame\n",
@@ -284,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "smoking-robert",
+   "id": "grave-evening",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hollywood-silver",
+   "id": "international-princess",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nervous-denmark",
+   "id": "explicit-elevation",
    "metadata": {},
    "source": [
     "### Create a scatterplot showing elevation values for all sites"
@@ -313,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "genetic-period",
+   "id": "median-fence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "experimental-grade",
+   "id": "religious-titanium",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "approximate-converter",
+   "id": "double-trance",
    "metadata": {},
    "source": [
     "### Exclude the Alaska (AK) points to isolate points over Western U.S.\n",
@@ -349,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "conscious-indonesia",
+   "id": "acknowledged-serve",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +326,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "japanese-frederick",
+   "id": "taken-pierce",
    "metadata": {},
    "source": [
     "* Alternatively, can use a spatial filter (see GeoPandas `cx` indexer functionality for a bounding box)"
@@ -367,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "centered-closure",
+   "id": "occupational-pontiac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "focal-rubber",
+   "id": "demonstrated-retention",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "desirable-refund",
+   "id": "fuzzy-picture",
    "metadata": {},
    "source": [
     "### Update your scatterplot as sanity check\n",
@@ -397,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "minus-spotlight",
+   "id": "painted-tender",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "loaded-stake",
+   "id": "parental-reputation",
    "metadata": {},
    "source": [
     "### Export SNOTEL site GeoDataFrame as a geojson\n",
@@ -419,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "separate-stack",
+   "id": "aquatic-batman",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nasty-surveillance",
+   "id": "polar-commons",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "wooden-dodge",
+   "id": "fourth-lodge",
    "metadata": {},
    "source": [
     "## Part 2: Spatial filter points by polygon"
@@ -448,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hollow-license",
+   "id": "lovely-cabinet",
    "metadata": {},
    "source": [
     "### Load Grand Mesa Polygon"
@@ -457,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "earlier-tract",
+   "id": "resistant-wealth",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adjustable-improvement",
+   "id": "ethical-coach",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "correct-comparison",
+   "id": "chubby-calcium",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "piano-sphere",
+   "id": "adjustable-seafood",
    "metadata": {},
    "source": [
     "## A quick aside on `geometry` objects"
@@ -494,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "given-commissioner",
+   "id": "checked-technician",
    "metadata": {},
    "source": [
     "### Vector data contain `geometry` objects\n",
@@ -506,7 +474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "visible-programmer",
+   "id": "guilty-material",
    "metadata": {},
    "source": [
     "![Geometry types](https://datacarpentry.org/organization-geospatial/fig/dc-spatial-vector/pnt_line_poly.png)\n",
@@ -515,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cellular-relations",
+   "id": "tropical-poetry",
    "metadata": {},
    "source": [
     "### Isolate Polygon geometry within GeoDataFrame"
@@ -524,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "heavy-messenger",
+   "id": "welcome-steering",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "interesting-dispatch",
+   "id": "cordless-scholarship",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "plastic-jackson",
+   "id": "fixed-tuition",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "located-conducting",
+   "id": "nutritional-gather",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "considerable-liver",
+   "id": "collected-walter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "appreciated-township",
+   "id": "lined-virtue",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "distinct-ghost",
+   "id": "buried-karaoke",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "executive-talent",
+   "id": "smoking-provincial",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,7 +572,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "negative-forty",
+   "id": "earlier-accuracy",
    "metadata": {},
    "source": [
     "### Generate boolean index for points that intersect the polygon\n",
@@ -614,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "equal-poster",
+   "id": "revolutionary-homework",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "surprising-exposure",
+   "id": "least-wednesday",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "behavioral-intent",
+   "id": "crude-brick",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -643,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "spectacular-exception",
+   "id": "subsequent-eligibility",
    "metadata": {},
    "source": [
     "### Use fancy indexing to isolate points and return new GeoDataFrame"
@@ -652,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ancient-taylor",
+   "id": "broke-console",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "medium-ceremony",
+   "id": "incorrect-wisdom",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "minute-czech",
+   "id": "rotary-tribe",
    "metadata": {},
    "source": [
     "### Quick plot"
@@ -680,7 +648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "facial-punch",
+   "id": "banner-background",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "saved-small",
+   "id": "pediatric-sociology",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -705,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "common-passion",
+   "id": "cheap-arrow",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,7 +682,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "flush-designation",
+   "id": "instrumental-timeline",
    "metadata": {},
    "source": [
     "### Add a basemap\n",
@@ -728,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "drawn-rabbit",
+   "id": "gross-satisfaction",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "earned-masters",
+   "id": "assured-nursery",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +716,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "atmospheric-superintendent",
+   "id": "banner-stockholm",
    "metadata": {},
    "source": [
     "## Part 3: Time series analysis for one station\n",
@@ -757,7 +725,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "legislative-prayer",
+   "id": "green-commitment",
    "metadata": {},
    "source": [
     "https://wcc.sc.egov.usda.gov/nwcc/site?sitenum=622&state=co"
@@ -766,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "metropolitan-aging",
+   "id": "bibliographic-collector",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -776,7 +744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "grateful-reporter",
+   "id": "confidential-speaker",
    "metadata": {},
    "source": [
     "### Get available measurements for this site\n",
@@ -786,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "honest-division",
+   "id": "homeless-pakistan",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -795,7 +763,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adapted-blade",
+   "id": "arbitrary-jungle",
    "metadata": {},
    "source": [
     "* _H = \"hourly\"\n",
@@ -805,7 +773,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "motivated-malawi",
+   "id": "parliamentary-shopper",
    "metadata": {},
    "source": [
     "### Let's consider the 'SNOTEL:SNWD_D' variable (Daily Snow Depth)\n",
@@ -818,7 +786,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "injured-rapid",
+   "id": "offshore-chapter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -831,7 +799,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "blocked-mechanism",
+   "id": "senior-cleaning",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -844,7 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "operational-czech",
+   "id": "tested-funds",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +821,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "joint-dayton",
+   "id": "united-chart",
    "metadata": {},
    "source": [
     "### Define a function to fetch data\n",
@@ -864,7 +832,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "patent-style",
+   "id": "searching-mounting",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -895,7 +863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "native-episode",
+   "id": "incoming-clearing",
    "metadata": {},
    "source": [
     "### Use this function to get the full 'SNOTEL:SNWD_D' record for one station\n",
@@ -906,7 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adaptive-dinner",
+   "id": "adjustable-haiti",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -918,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "facial-inventory",
+   "id": "naked-advocate",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -930,7 +898,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "crude-walker",
+   "id": "ethical-peripheral",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,7 +908,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "capable-temple",
+   "id": "precise-explanation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -951,7 +919,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "subsequent-grill",
+   "id": "grateful-desert",
    "metadata": {},
    "source": [
     "### Create a quick plot to view the time series\n",
@@ -962,7 +930,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mounted-bubble",
+   "id": "incredible-republic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -971,7 +939,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "restricted-absence",
+   "id": "bored-album",
    "metadata": {},
    "source": [
     "### Compute the integer day of year (doy) and integer day of water year (dowy)\n",
@@ -986,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "needed-secondary",
+   "id": "varied-translator",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fallen-recall",
+   "id": "hourly-charm",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1014,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "accomplished-sequence",
+   "id": "binding-wellington",
    "metadata": {},
    "source": [
     "### Compute statistics for each day of the water year, using values from all years\n",
@@ -1025,7 +993,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "consecutive-mauritius",
+   "id": "internal-brave",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,7 +1003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "offensive-biology",
+   "id": "dressed-grammar",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1045,7 +1013,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "living-grove",
+   "id": "marine-worthy",
    "metadata": {},
    "source": [
     "### Create a plot of these aggregated dowy values\n",
@@ -1055,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "structured-zambia",
+   "id": "invisible-fortune",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1080,7 +1048,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "intellectual-doctor",
+   "id": "electronic-repository",
    "metadata": {},
    "source": [
     "### Add the daily snow depth values for the current water year\n",
@@ -1093,7 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "premium-bristol",
+   "id": "funny-junior",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1105,7 +1073,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lesser-tract",
+   "id": "engaged-papua",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1116,7 +1084,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "colonial-mattress",
+   "id": "driving-hearts",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1139,7 +1107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lovely-theology",
+   "id": "challenging-award",
    "metadata": {},
    "source": [
     "### What was the percentage of \"normal\" snow depth on April 1 of this year?\n",
@@ -1149,7 +1117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "integrated-numbers",
+   "id": "vanilla-memory",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1159,7 +1127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "emerging-rogers",
+   "id": "interracial-voluntary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1170,7 +1138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "physical-extreme",
+   "id": "precise-battle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1180,7 +1148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "falling-warren",
+   "id": "chinese-bishop",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,7 +1159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "educational-murray",
+   "id": "burning-africa",
    "metadata": {},
    "source": [
     "### Index DataFrame by date or date range\n",
@@ -1201,7 +1169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "complicated-racing",
+   "id": "relevant-python",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1212,7 +1180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "static-separate",
+   "id": "exempt-nightlife",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1223,7 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "domestic-pride",
+   "id": "cathedral-aaron",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "applied-broadcasting",
+   "id": "active-moscow",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1242,7 +1210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "proud-horse",
+   "id": "designing-village",
    "metadata": {},
    "source": [
     "### Query multiple sites\n",
@@ -1252,7 +1220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fancy-cassette",
+   "id": "hourly-tuesday",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "standing-estate",
+   "id": "signed-foundation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1280,7 +1248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "expanded-printer",
+   "id": "ongoing-authority",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1290,7 +1258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tracked-receipt",
+   "id": "united-shipping",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1301,7 +1269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "civil-score",
+   "id": "metallic-group",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1310,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "immediate-rwanda",
+   "id": "union-skating",
    "metadata": {},
    "source": [
     "### Scatterplot to compare corresponding values"
@@ -1319,7 +1287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "twenty-brick",
+   "id": "mathematical-bowling",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1329,7 +1297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "happy-union",
+   "id": "third-stick",
    "metadata": {},
    "source": [
     "### Determine Pearson's correlation coefficient for the two time series\n",
@@ -1341,7 +1309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "transsexual-syria",
+   "id": "early-sixth",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1350,7 +1318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "romantic-fusion",
+   "id": "alpine-train",
    "metadata": {},
    "source": [
     "Highly correlated snow depth records for these two sites!"
@@ -1358,7 +1326,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "magnetic-transportation",
+   "id": "organizational-messenger",
    "metadata": {},
    "source": [
     "## Summary"

--- a/book/tutorials/geospatial/raster.ipynb
+++ b/book/tutorials/geospatial/raster.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "essential-origin",
+   "id": "statistical-words",
    "metadata": {},
    "source": [
     "# Raster data\n",
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "rubber-packet",
+   "id": "impossible-class",
    "metadata": {},
    "source": [
     "## Raster Basics\n",
@@ -33,7 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tender-water",
+   "id": "stretch-directory",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,8 +58,29 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "outside-ownership",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%%bash \n",
+    "\n",
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "entitled-stomach",
+   "id": "based-ireland",
    "metadata": {},
    "source": [
     "## Elevation rasters\n",
@@ -77,18 +98,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accurate-bleeding",
+   "id": "second-treat",
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%bash\n",
+    "\n",
     "# Get data from LPDAAC and unzip\n",
-    "!wget -q -nc https://e4ftl01.cr.usgs.gov//DP132/MEASURES/NASADEM_HGT.001/2000.02.11/NASADEM_HGT_n39w109.zip\n",
-    "!unzip -n NASADEM_HGT_n39w109.zip "
+    "DATADIR='/tmp/tutorial-data/geospatial/raster'\n",
+    "mkdir -p ${DATADIR}\n",
+    "wget -q -nc https://e4ftl01.cr.usgs.gov/DP132/MEASURES/NASADEM_HGT.001/2000.02.11/NASADEM_HGT_n39w109.zip \n",
+    "unzip -n NASADEM_HGT_n39w109.zip -d ${DATADIR}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "accessory-eclipse",
+   "id": "conceptual-venezuela",
    "metadata": {},
    "source": [
     "### Rasterio\n",
@@ -99,13 +124,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stable-bahrain",
+   "id": "unable-munich",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "# NOTE: This reads just the metadata into memory, not the whole file\n",
-    "path = 'n39w109.hgt'\n",
+    "path = '/tmp/tutorial-data/geospatial/n39w109.hgt'\n",
     "with rasterio.open(path) as src:\n",
     "    print(src.profile)"
    ]
@@ -113,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afraid-questionnaire",
+   "id": "blond-columbus",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "involved-founder",
+   "id": "phantom-webmaster",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "falling-partner",
+   "id": "collect-flower",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "operational-muslim",
+   "id": "cross-helen",
    "metadata": {},
    "source": [
     "### Rioxarray\n",
@@ -176,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "active-garage",
+   "id": "alive-qatar",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ethical-height",
+   "id": "split-bryan",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -197,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hindu-mainland",
+   "id": "theoretical-crawford",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "located-times",
+   "id": "guided-perry",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "theoretical-eligibility",
+   "id": "japanese-longitude",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "surrounded-buffer",
+   "id": "quality-struggle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cutting-riding",
+   "id": "worthy-third",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "treated-hierarchy",
+   "id": "endless-invitation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aquatic-summary",
+   "id": "theoretical-niagara",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "auburn-algeria",
+   "id": "material-julian",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nasty-deployment",
+   "id": "associate-sunset",
    "metadata": {},
    "source": [
     "## Comparing rasters\n",
@@ -311,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "round-easter",
+   "id": "blank-confidence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "assumed-birthday",
+   "id": "wicked-thanks",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sharp-biology",
+   "id": "guilty-minutes",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "external-stable",
+   "id": "framed-scratch",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "little-recognition",
+   "id": "hairy-adventure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "concerned-owner",
+   "id": "every-revolution",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "exclusive-snake",
+   "id": "first-accordance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "impressed-testament",
+   "id": "productive-geography",
    "metadata": {},
    "source": [
     "```{warning}\n",
@@ -427,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "renewable-channels",
+   "id": "congressional-oklahoma",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "beginning-frank",
+   "id": "criminal-resort",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pointed-flour",
+   "id": "middle-stewart",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "tough-essex",
+   "id": "material-daughter",
    "metadata": {},
    "source": [
     "```{admonition} execercises\n",

--- a/book/tutorials/geospatial/raster.ipynb
+++ b/book/tutorials/geospatial/raster.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "statistical-words",
+   "id": "capital-retreat",
    "metadata": {},
    "source": [
     "# Raster data\n",
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "impossible-class",
+   "id": "plain-municipality",
    "metadata": {},
    "source": [
     "## Raster Basics\n",
@@ -33,7 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stretch-directory",
+   "id": "potential-binary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,27 +60,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "outside-ownership",
+   "id": "engaged-definition",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%%bash \n",
+    "%%bash \n",
     "\n",
-    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
-    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "# Retrieve a copy of data files used in this tutorial from Zenodo.org:\n",
+    "# Re-running this cell will not re-download things if they already exist\n",
     "\n",
-    "#cd /tmp\n",
-    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
-    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
-    "#unzip -n tutorial-data.zip\n",
-    "\n",
-    "# temporary equivalent\n",
-    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+    "mkdir -p /tmp/tutorial-data\n",
+    "cd /tmp/tutorial-data\n",
+    "wget -q -nc -O data.zip https://zenodo.org/record/5504396/files/geospatial.zip\n",
+    "unzip -q -n data.zip\n",
+    "rm data.zip"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "based-ireland",
+   "id": "later-czech",
    "metadata": {},
    "source": [
     "## Elevation rasters\n",
@@ -98,22 +96,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "second-treat",
+   "id": "designing-sellers",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
+    "#%%bash\n",
     "\n",
-    "# Get data from LPDAAC and unzip\n",
-    "DATADIR='/tmp/tutorial-data/geospatial/raster'\n",
-    "mkdir -p ${DATADIR}\n",
-    "wget -q -nc https://e4ftl01.cr.usgs.gov/DP132/MEASURES/NASADEM_HGT.001/2000.02.11/NASADEM_HGT_n39w109.zip \n",
-    "unzip -n NASADEM_HGT_n39w109.zip -d ${DATADIR}"
+    "# Get data directly from NASA LPDAAC and unzip\n",
+    "\n",
+    "#DATADIR='/tmp/tutorial-data/geospatial/raster'\n",
+    "#mkdir -p ${DATADIR}\n",
+    "#wget -q -nc https://e4ftl01.cr.usgs.gov/DP132/MEASURES/NASADEM_HGT.001/2000.02.11/NASADEM_HGT_n39w109.zip \n",
+    "#unzip -n NASADEM_HGT_n39w109.zip -d ${DATADIR}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "conceptual-venezuela",
+   "id": "random-deployment",
    "metadata": {},
    "source": [
     "### Rasterio\n",
@@ -124,12 +123,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "unable-munich",
+   "id": "occasional-transfer",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NOTE: This reads just the metadata into memory, not the whole file\n",
-    "path = '/tmp/tutorial-data/geospatial/n39w109.hgt'\n",
+    "# Open a raster image in a zipped archive\n",
+    "# https://rasterio.readthedocs.io/en/latest/topics/datasets.html\n",
+    "path = 'zip:///tmp/tutorial-data/geospatial/NASADEM_HGT_n39w109.zip!n39w109.hgt'\n",
     "with rasterio.open(path) as src:\n",
     "    print(src.profile)"
    ]
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "blond-columbus",
+   "id": "casual-colombia",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "phantom-webmaster",
+   "id": "contemporary-japan",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "collect-flower",
+   "id": "exclusive-roller",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cross-helen",
+   "id": "final-momentum",
    "metadata": {},
    "source": [
     "### Rioxarray\n",
@@ -200,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alive-qatar",
+   "id": "amber-prayer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "split-bryan",
+   "id": "given-pearl",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -221,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "theoretical-crawford",
+   "id": "olympic-grammar",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "guided-perry",
+   "id": "suburban-windsor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "japanese-longitude",
+   "id": "anonymous-hawaii",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "quality-struggle",
+   "id": "sitting-diesel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "worthy-third",
+   "id": "connected-necessity",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "endless-invitation",
+   "id": "exclusive-mongolia",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "theoretical-niagara",
+   "id": "handy-accounting",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "material-julian",
+   "id": "unexpected-fetish",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "associate-sunset",
+   "id": "loved-bangladesh",
    "metadata": {},
    "source": [
     "## Comparing rasters\n",
@@ -335,18 +335,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "blank-confidence",
+   "id": "preliminary-planning",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Can use AWS CLI to interact with this data\n",
+    "# Can use AWS CLI to interact with this open data\n",
     "!aws --no-sign-request s3 ls s3://copernicus-dem-30m/Copernicus_DSM_COG_10_N39_00_W109_00_DEM/Copernicus_DSM_COG_10_N39_00_W109_00_DEM.tif"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wicked-thanks",
+   "id": "amended-sensitivity",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "guilty-minutes",
+   "id": "working-lounge",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "framed-scratch",
+   "id": "distant-joint",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,20 +394,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hairy-adventure",
+   "id": "accompanied-category",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Ensure the grid of one raster exactly matches another (same projection, resolution, and extents)\n",
-    "# NOTE: these two raster happen to already be on an aligned grid\n",
-    "daR = daC.rio.reproject_match(da)\n",
+    "# NOTE: these two rasters happen to already be on an aligned grid\n",
+    "\n",
+    "# There are many options for how to resample a warped raster grid (nearest, bilinear, etc)\n",
+    "#print(list(rasterio.enums.Resampling))\n",
+    "\n",
+    "daR = daC.rio.reproject_match(da, resampling=rasterio.enums.Resampling.nearest)\n",
     "daR"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "every-revolution",
+   "id": "spectacular-logic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "first-accordance",
+   "id": "touched-effects",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +439,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "productive-geography",
+   "id": "classified-exclusion",
    "metadata": {},
    "source": [
     "```{warning}\n",
@@ -451,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "congressional-oklahoma",
+   "id": "engaged-verification",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "criminal-resort",
+   "id": "structural-shade",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "middle-stewart",
+   "id": "weighted-pulse",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +493,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "material-daughter",
+   "id": "empty-barrier",
    "metadata": {},
    "source": [
     "```{admonition} execercises\n",

--- a/book/tutorials/lidar/ASO_data_tutorial.ipynb
+++ b/book/tutorials/lidar/ASO_data_tutorial.ipynb
@@ -88,15 +88,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install pycrs>=1 --no-deps"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# general purpose data manipulation and analysis\n",
     "import numpy as np\n",
     "\n",
@@ -115,18 +106,7 @@
     "from shapely.geometry import box\n",
     "\n",
     "# import packages for viewing the data\n",
-    "import matplotlib.pyplot as pyplot\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#define paths\n",
-    "import os\n",
-    "CURDIR = os.path.dirname(os.path.realpath(\"__file__\"))"
+    "import matplotlib.pyplot as pyplot"
    ]
   },
   {
@@ -965,13 +945,6 @@
     "\n",
     "But you can find ASO bare earth DTMs and other ASO data, including 3 m and 50 m snow depth, SWE across other sites and years [here](https://nsidc.org/data/aso/data-summaries)\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/book/tutorials/lidar/ICESat2_tutorial.ipynb
+++ b/book/tutorials/lidar/ICESat2_tutorial.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "systematic-habitat",
+   "id": "current-friendship",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,14 +17,13 @@
     "from IPython.core.display import HTML \n",
     "import hvplot.xarray\n",
     "import pandas as pd\n",
-    "import rioxarray\n",
-    "import s3fs"
+    "import rioxarray"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "featured-lebanon",
+   "id": "together-preparation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,10 +34,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "headed-genre",
+   "id": "presidential-emerald",
    "metadata": {},
    "source": [
-    "# Introduction\n",
+    "# ICESat-2\n",
     "\n",
     "ICESat-2 is a laser altimeter designed to precisely measure the height of snow and ice surfaces using green lasers with small footprints.  Although ICESat-2 doesn't measure surface heights with the same spatial density as airborne laser altimeters, its global spatial coverage makes it a tempting source of free data about snow surfaces.  In this tutorial we will:\n",
     "\n",
@@ -50,7 +49,7 @@
     "\n",
     "4. Request custom processed height estimates from the SlideRule project.\n",
     "\n",
-    "## ICESat-2 measurements and coverage\n",
+    "## Measurements and coverage\n",
     "\n",
     "ICESat-2 measures surface heights with six laser beams, grouped into three pairs separated by 3 km, with a 90-m separation between the beams in each pair.\n",
     "\n",
@@ -60,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "utility-salad",
+   "id": "impressive-greeting",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "finite-november",
+   "id": "critical-queens",
    "metadata": {},
    "source": [
     "ICESat-2 flies a repeat orbit with 1387 ground tracks every 91 days, but over Grand Mesa, the collection strategy (up until now) has designed to optimize spatial coverage, so the measurements are shifted to the left and right of the repeat tracks to help densify the dataset.  We should expect to see tracks running (approximately) north-south over the Mesa, in tripplets of pairs that are scattered from east to west.   Because clouds often block the laser, not every track will return usable data.\n"
@@ -78,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bridal-christian",
+   "id": "annual-bottom",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "given-slovak",
+   "id": "julian-enterprise",
    "metadata": {},
    "source": [
     "We describe ICESat-2's beam layout on the ground based on pairs (numbered 1, 2, and 3, from left to right) and the location of each beam in each pair (L, R).  Thus GT2L is the left beam in the center pair.  In each pair, one beam is always stronger than the other (to help penetrate thin clouds), but since the spacecraft sometimes reverses its orientation to keep the solar panels illuminated, the strong beam can be either left or right, depending on the phase of the mission.\n"
@@ -95,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "educational-density",
+   "id": "tired-france",
    "metadata": {},
    "source": [
     "## Basemap (Sentinel)\n",
@@ -106,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "listed-textbook",
+   "id": "indoor-interference",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "undefined-investor",
+   "id": "liable-bradford",
    "metadata": {},
    "source": [
     "## Searching for ICESat-2 data using IcePyx\n",
@@ -151,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "oriental-agriculture",
+   "id": "complicated-reach",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "arranged-subscriber",
+   "id": "abroad-bracket",
    "metadata": {},
    "source": [
     "To run this next section, you'll need to setup your netrc file to connect to nasa earthdata.  During the hackweek we will use machine credentials, but afterwards, you may need to use your own credentials.  The login procedure is in the next cell, commented out."
@@ -173,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "medical-young",
+   "id": "utility-growth",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "urban-sculpture",
+   "id": "scientific-handle",
    "metadata": {},
    "source": [
     "Once we're logged in, the avail_granules() fetches a list of available ATL03 granules:"
@@ -193,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "exact-carnival",
+   "id": "growing-trick",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fundamental-clock",
+   "id": "cultural-order",
    "metadata": {},
    "source": [
     "The filename for each granule (which contains lots of handy information) is in the 'producer_granule_id' field: "
@@ -211,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "measured-bermuda",
+   "id": "divine-degree",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "angry-effect",
+   "id": "charged-probe",
    "metadata": {},
    "source": [
     "The filename contains ATL03_YYYYMMDDHHMMSS_TTTTCCRR_rrr_vv.h5 where:\n",
@@ -237,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "happy-syndrome",
+   "id": "inside-delicious",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cooperative-device",
+   "id": "prepared-engineer",
    "metadata": {},
    "source": [
     "From this point, the very capable icepyx interface allows you to order either full data granules or subsets of granules from NSIDC.  Further details are available from https://icepyx.readthedocs.io/en/latest/, and their 'examples' pages are quite helpful.  Note that ATL03 photon data granules are somewhat cumbersome, so downloading them without subsetting will be time consuming, and requesting subsetting from NSIDC may take a while.  \n",
@@ -266,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "located-banana",
+   "id": "guided-enough",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "explicit-oregon",
+   "id": "rocky-showcase",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "diverse-catering",
+   "id": "ambient-thumb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +354,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "accomplished-tourist",
+   "id": "affected-grass",
    "metadata": {},
    "source": [
     "What we see in this plot is Grand Mesa, with lines showing data from the center beams of several tracks passing across it.  A few of these tracks have been repeated, but most are offset from the others.  Looking at these, it should be clear that the quality of the data is not consistent from track to track.  Some are nearly continuous, others have gaps, and other still have no data at all and are not plotted here.  Remember, though, that what we've plotted here are just the center beams.  There are a total of two more beam pairs, and a total of five more beams!\n",
@@ -366,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "higher-suicide",
+   "id": "composite-holly",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "placed-crawford",
+   "id": "macro-shannon",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "african-mambo",
+   "id": "alike-blake",
    "metadata": {},
    "source": [
     "Based on the axis limits I filled in, Track 295 has two repeats over the mesa that nearly coincide.\n",
@@ -411,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "modified-general",
+   "id": "animated-screening",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "active-ireland",
+   "id": "extra-salem",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +450,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adult-oxygen",
+   "id": "received-strap",
    "metadata": {},
    "source": [
     "On the left we see a plot of all six beams crossing (or almost crossing) Grand Mesa, in April of 2020.  If you zoom in on the plot, you can distinguish the beam pairs into separate beams.  On the right, we see one of the central beams crossing the mesa from south to north.  There is a broad band of noise photons that were close enough to the ground to be telemetered by the satellite, and a much narrower band (in red) of photons identified by the processing software as likely coming from the ground."
@@ -459,7 +458,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "toxic-navigation",
+   "id": "piano-annex",
    "metadata": {},
    "source": [
     "These data give a maximum of detail about what the surface looks like to ICESat-2.  to reduce this to elevation data, telling the surface height at specific locations, there are a few options:\n",
@@ -473,7 +472,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "subject-scott",
+   "id": "automotive-alberta",
    "metadata": {},
    "source": [
     "## Ordering surface-height segments from SlideRule\n",
@@ -484,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "organic-thumb",
+   "id": "prime-vermont",
    "metadata": {},
    "source": [
     "You'll need to install the sliderule-python package, available from https://github.com/ICESat2-SlideRule/sliderule-python\n",
@@ -494,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "separated-thailand",
+   "id": "federal-aside",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +503,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "practical-lender",
+   "id": "approved-edgar",
    "metadata": {},
    "source": [
     "We will submit a query to sliderule to process all of the data that CMR finds for our region, fitting 20-meter line-segments to all of the photons with medium-or-better signal confidence"
@@ -513,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "focused-grounds",
+   "id": "turned-google",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +549,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "outstanding-warrant",
+   "id": "reported-hazard",
    "metadata": {},
    "source": [
     "SlideRule complains when it tries to calculate heights within our ROI for ground tracks that don't intersect the ROI.  This happens quite a bit because the CMR service that IcePyx and SlideRule use to search for the data uses a generous buffer on each ICESat-2 track.  It shouldn't bother us.  In fact, we have quite a few tracks for our region.\n",
@@ -561,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "blocked-musical",
+   "id": "senior-shepherd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "logical-press",
+   "id": "technical-tracker",
    "metadata": {},
    "source": [
     "As we saw a few cells up, for track 295 cycles 7 and 8 are nearly exact repeats.  Cycle 7 was April 2020, cycle 8 was July 2020.  Could it be that we can measure snow depth in April by comparing the two?  Let's plot spot 3 for both!"
@@ -583,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "amended-magic",
+   "id": "precise-column",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +600,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "jewish-corner",
+   "id": "unusual-merchandise",
    "metadata": {},
    "source": [
     "To try to get at snow depth, we can look for bare-earth DTMs here:\n",
@@ -612,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dying-truck",
+   "id": "persistent-click",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "increasing-listing",
+   "id": "official-monitor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +648,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "instant-titanium",
+   "id": "statutory-emergency",
    "metadata": {},
    "source": [
     "To compare the DTM directly with the ICESat-2 data, we'll need to sample it at the ICESat-2 points.  There are probably ways to do this directly in xarray, but I'm not an expert.  Here we'll use a scipy interpolator:"
@@ -658,7 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "patent-decline",
+   "id": "fatal-tribute",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "endangered-culture",
+   "id": "emerging-jamaica",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "disciplinary-scottish",
+   "id": "personalized-filling",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +706,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "varying-nurse",
+   "id": "effective-resource",
    "metadata": {},
    "source": [
     "The DTM is below the April ICESat-2 heights.  That's probably not right, and it's because we don't have the vertical datums correct here (ICESat-2 WGS84, the DEM is NAD83).  That's OK!  Since we have multiple passes over the same DEM, we can use the DEM to correct for spatial offsets between the measurements.  Let's use the DEM to correct for differences between the July and April data:"
@@ -716,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "realistic-senator",
+   "id": "aboriginal-possible",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +742,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "immune-minister",
+   "id": "foreign-auction",
    "metadata": {},
    "source": [
     "This looks good, if a little noisy.  We could get a better comparison by (1) using multiple ICESat-2 tracks to extract a mean snow-off difference between the DTM and ICESat-2, or (2). finding adjacent pairs of measurements  between the two tracks, and comparing their heights directly.  These are both good goals for projects!\n"
@@ -751,7 +750,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "atomic-madness",
+   "id": "naval-discount",
    "metadata": {},
    "source": [
     "## Further reading:\n",
@@ -768,7 +767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vertical-simon",
+   "id": "expanded-prince",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/tutorials/machine-learning/Machine_Learning_Tutorial.ipynb
+++ b/book/tutorials/machine-learning/Machine_Learning_Tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "requested-victor",
+   "id": "three-bottom",
    "metadata": {},
    "source": [
     "# Introduction to Machine Learning \n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "competent-honduras",
+   "id": "nervous-drove",
    "metadata": {},
    "source": [
     "## Learning Outcomes\n",
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "outer-gallery",
+   "id": "extended-measurement",
    "metadata": {},
    "source": [
     "## Load Dataset\n",
@@ -88,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tight-blogger",
+   "id": "tutorial-missouri",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "checked-passenger",
+   "id": "corrected-exhaust",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "capital-shelf",
+   "id": "devoted-jimmy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "traditional-hobby",
+   "id": "academic-paragraph",
    "metadata": {},
    "source": [
     "The data used in this tutorial is already clean. The data cleaning was done in a separate notebook, and it is available for anyone interested."
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cleared-bradley",
+   "id": "shaped-camping",
    "metadata": {},
    "source": [
     "## Train and Test Sets\n",
@@ -146,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fantastic-filter",
+   "id": "gentle-ethernet",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "basic-kruger",
+   "id": "herbal-equivalent",
    "metadata": {},
    "source": [
     "### Inspect the Data\n",
@@ -169,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "danish-healthcare",
+   "id": "caroline-duplicate",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adjustable-korea",
+   "id": "unable-natural",
    "metadata": {},
    "source": [
     "Each panel of the scatterplot matrix is a scatterplot for a pair of variables whose identities are given by the corresponding row and column labels. None of the features have a linear relationship with $\\texttt{snow_depth}$. This may indicate that a linear model might not be the best option."
@@ -186,7 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "tested-magnet",
+   "id": "speaking-glossary",
    "metadata": {},
    "source": [
     "**Descriptive Statistics**\n",
@@ -204,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "smaller-interstate",
+   "id": "capable-controversy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "solid-apartment",
+   "id": "stable-tragedy",
    "metadata": {},
    "source": [
     "### Normalization\n",
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "universal-algebra",
+   "id": "small-dress",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stylish-physiology",
+   "id": "spread-ceramic",
    "metadata": {},
    "source": [
     "### Sepatare Features from Labels\n",
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "everyday-sustainability",
+   "id": "complicated-husband",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nuclear-deputy",
+   "id": "scheduled-configuration",
    "metadata": {},
    "source": [
     "## Why Estimate $f$?\n",
@@ -362,7 +362,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "biological-antenna",
+   "id": "civilian-louis",
    "metadata": {},
    "source": [
     "## Modeling Setup\n",
@@ -373,19 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "technological-charm",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# NOTE: this part of the tutorial uses additional libraries not in the default snowex jupyterhub\n",
-    "# mamba is a python package management alternative to conda and pip https://github.com/mamba-org/mamba\n",
-    "!mamba install -y -q tensorflow"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "green-agreement",
+   "id": "iraqi-ceremony",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "distinguished-consultancy",
+   "id": "substantial-memphis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +394,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "super-mixer",
+   "id": "numerous-state",
    "metadata": {},
    "source": [
     "The machine learning algorithm uses a linear regression model to fit the features to the outcome. It will initialize different weights depending on the seed. We define a random seed so that we get same result each time we do the regression."
@@ -415,7 +403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "received-redhead",
+   "id": "continuous-theology",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "elect-inspector",
+   "id": "considerable-referral",
    "metadata": {},
    "source": [
     "* **Compile**"
@@ -438,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "several-category",
+   "id": "proprietary-machinery",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pressed-canyon",
+   "id": "amino-alberta",
    "metadata": {},
    "source": [
     "The mean squared error is minimized to find optimal parameters. A discussion of diffent optimization methods is provided in Appendix A."
@@ -456,7 +444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "frank-maintenance",
+   "id": "durable-software",
    "metadata": {},
    "source": [
     "* **Print Architecture**"
@@ -465,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "academic-train",
+   "id": "located-reset",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mexican-surge",
+   "id": "fiscal-thesis",
    "metadata": {},
    "source": [
     "Note since there are 4 features, we have 5 regression parameters."
@@ -482,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "systematic-greek",
+   "id": "coupled-ballot",
    "metadata": {},
    "source": [
     "* **Fit Model**\n",
@@ -493,7 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "supposed-watch",
+   "id": "wrong-living",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "encouraging-laser",
+   "id": "supported-chicago",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -518,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "incorrect-crime",
+   "id": "synthetic-theater",
    "metadata": {},
    "source": [
     "### Linear Regression Coefficient\n",
@@ -529,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "particular-compound",
+   "id": "suitable-ontario",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fitted-record",
+   "id": "marine-twelve",
    "metadata": {},
    "source": [
     "**model**: $\\texttt{snow_depth} = 0.18 - 0.31 \\texttt{amplitude} - 0.14 \\texttt{coherence} + 0.40\\texttt{phase} + 0.40\\texttt{inc_ang} $ "
@@ -546,7 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "infinite-aging",
+   "id": "loving-gazette",
    "metadata": {},
    "source": [
     "## Neural Networks\n",
@@ -592,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "numeric-porter",
+   "id": "dutch-citation",
    "metadata": {},
    "source": [
     "### Visualizing Activation Functions"
@@ -601,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "elementary-newsletter",
+   "id": "approved-linux",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "english-richards",
+   "id": "fundamental-climate",
    "metadata": {},
    "source": [
     "### Families of Neural Networks\n",
@@ -702,7 +690,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "smooth-blackjack",
+   "id": "silent-reset",
    "metadata": {},
    "source": [
     "### Feedforward Neural Network\n",
@@ -715,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "social-trigger",
+   "id": "proprietary-miracle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -735,7 +723,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "numeric-consistency",
+   "id": "spiritual-campus",
    "metadata": {},
    "source": [
     "* **Compile**\n",
@@ -746,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "crazy-extraction",
+   "id": "prepared-seminar",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,7 +744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ruled-indonesia",
+   "id": "friendly-wings",
    "metadata": {},
    "source": [
     "* **Print Architecture**"
@@ -765,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "clear-night",
+   "id": "protecting-identification",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +762,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "representative-finder",
+   "id": "aboriginal-moscow",
    "metadata": {},
    "source": [
     "Number of weights connecting the input and the first hidden layer = (1000 $\\times$ 4) + 1000(bias) = 5000 \n",
@@ -800,7 +788,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "documented-compiler",
+   "id": "packed-arctic",
    "metadata": {},
    "source": [
     "* **Fit Model**"
@@ -809,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "approximate-costume",
+   "id": "coordinate-deficit",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -822,7 +810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "clean-cathedral",
+   "id": "revised-tourism",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -836,7 +824,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "coated-dragon",
+   "id": "defined-papua",
    "metadata": {},
    "source": [
     "### Prediction\n",
@@ -847,7 +835,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stupid-reservation",
+   "id": "dominican-majority",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -875,7 +863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "infinite-repair",
+   "id": "southeast-smooth",
    "metadata": {},
    "source": [
     "### Check Performance"
@@ -884,7 +872,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "integrated-nitrogen",
+   "id": "following-theme",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "extended-tower",
+   "id": "matched-bearing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -914,7 +902,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adverse-lightning",
+   "id": "acute-bahrain",
    "metadata": {},
    "source": [
     "### Visualize Performance"
@@ -923,7 +911,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "attractive-entry",
+   "id": "arbitrary-angel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -944,7 +932,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "loaded-wings",
+   "id": "hired-citizenship",
    "metadata": {},
    "source": [
     "### Visualize Error"
@@ -953,7 +941,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "explicit-trace",
+   "id": "signed-yesterday",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -977,7 +965,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stretch-diana",
+   "id": "mathematical-retail",
    "metadata": {},
    "source": [
     "### Save the Best Model"
@@ -986,7 +974,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tight-genealogy",
+   "id": "rolled-campaign",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -998,7 +986,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "restricted-plain",
+   "id": "focal-escape",
    "metadata": {},
    "source": [
     "### Main Challenges of Machine Learning\n",
@@ -1009,7 +997,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "north-photographer",
+   "id": "considerable-paris",
    "metadata": {},
    "source": [
     "### Improving your Deep Learning Model\n",
@@ -1022,7 +1010,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "experienced-memorial",
+   "id": "saved-actor",
    "metadata": {},
    "source": [
     "## Your Turn\n",
@@ -1036,7 +1024,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "induced-setting",
+   "id": "experienced-upset",
    "metadata": {},
    "source": [
     "## Reference\n",
@@ -1051,7 +1039,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unable-serve",
+   "id": "rotary-millennium",
    "metadata": {},
    "source": [
     "## Appendix A\n",
@@ -1116,7 +1104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "extensive-powder",
+   "id": "hungry-bracket",
    "metadata": {},
    "source": [
     "## Appendix B\n",

--- a/book/tutorials/microstructure/microstructure-tutorial.ipynb
+++ b/book/tutorials/microstructure/microstructure-tutorial.ipynb
@@ -414,18 +414,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%%bash \n",
+    "%%bash \n",
     "\n",
-    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
-    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "# Retrieve a copy of data files used in this tutorial from Zenodo.org:\n",
+    "# Re-running this cell will not re-download things if they already exist\n",
     "\n",
-    "#cd /tmp\n",
-    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
-    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
-    "#unzip -n tutorial-data.zip\n",
-    "\n",
-    "# temporary equivalent\n",
-    "!aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+    "mkdir -p /tmp/tutorial-data\n",
+    "cd /tmp/tutorial-data\n",
+    "wget -q -nc -O data.zip https://zenodo.org/record/5504396/files/microstructure.zip\n",
+    "unzip -q -n data.zip\n",
+    "rm data.zip"
    ]
   },
   {

--- a/book/tutorials/microstructure/microstructure-tutorial.ipynb
+++ b/book/tutorials/microstructure/microstructure-tutorial.ipynb
@@ -414,8 +414,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Pull in some tutorial datasets \n",
-    "!aws s3 sync --quiet s3://snowex-data/tutorial-data/microstructure/ /tmp/microstructure"
+    "#%%bash \n",
+    "\n",
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "!aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
    ]
   },
   {
@@ -424,7 +434,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = Profile.load('/tmp/microstructure/SMP/SNEX20_SMP_S19M1174_2N13_20200206.PNT',)\n",
+    "p = Profile.load('/tmp/tutorial-data/microstructure/SMP/SNEX20_SMP_S19M1174_2N13_20200206.PNT',)\n",
     "plt.plot(p.samples.distance, p.samples.force)\n",
     "# Prettify our plot a bit\n",
     "plt.title(p.name)\n",
@@ -517,7 +527,7 @@
    "outputs": [],
    "source": [
     "# read micro CT for 2N13\n",
-    "data_dir='/tmp/microstructure/microCT/txt/'\n",
+    "data_dir='/tmp/tutorial-data/microstructure/microCT/txt/'\n",
     "[SSA_CT,height_min,height_max]=read_CT_txt_files(data_dir)\n",
     "\n",
     "SSA_CT #check out the SSA values read in from MicroCT"
@@ -591,13 +601,6 @@
     "\n",
     "It might also be interesting to compare the data to hand hardness measured in the snowpit, and to traditional hand lens measurements. "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/book/tutorials/nsidc-access/nsidc-data-access.ipynb
+++ b/book/tutorials/nsidc-access/nsidc-data-access.ipynb
@@ -596,13 +596,6 @@
     "\n",
     "Additionally, the NASA Global Browse Imagery Service provides up to date, full resolution imagery for select NSIDC DAAC data sets as web services including WMTS, WMS, KML, and more. These layers can be accessed in GIS applications following guidance on the [GIBS documentation pages](https://wiki.earthdata.nasa.gov/display/GIBS/Geographic+Information+System+%28GIS%29+Usage). "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/book/tutorials/sar/sentinel1.ipynb
+++ b/book/tutorials/sar/sentinel1.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "mobile-scout",
+   "id": "mathematical-lobby",
    "metadata": {},
    "source": [
     "# Sentinel-1\n",
@@ -28,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "convertible-roberts",
+   "id": "governmental-population",
    "metadata": {
     "tags": [
      "remove-input"
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "elegant-raleigh",
+   "id": "arbitrary-sapphire",
    "metadata": {},
    "source": [
     "## Dive right in\n",
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "second-organizer",
+   "id": "functioning-accommodation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "parallel-monte",
+   "id": "embedded-simon",
    "metadata": {},
    "source": [
     "```{admonition} Interpretation\n",
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "former-intention",
+   "id": "placed-dialogue",
    "metadata": {},
    "source": [
     "```{admonition} Exercise\n",
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "preceding-verification",
+   "id": "accepting-batman",
    "metadata": {},
    "source": [
     "## Quick facts\n",
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mysterious-exhaust",
+   "id": "organizational-danger",
    "metadata": {},
    "source": [
     "## Search and Discovery\n",
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "operating-elder",
+   "id": "medieval-applicant",
    "metadata": {},
    "source": [
     "## Amplitude\n",
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "impossible-context",
+   "id": "prerequisite-border",
    "metadata": {
     "tags": [
      "hide-input"
@@ -214,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "thorough-deadline",
+   "id": "subtle-inflation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "suspected-tampa",
+   "id": "eligible-terrorist",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fallen-cleaners",
+   "id": "joined-simon",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "instructional-addiction",
+   "id": "adjustable-riding",
    "metadata": {},
    "source": [
     "```{admonition} Interpretation\n",
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lined-stranger",
+   "id": "binding-seeking",
    "metadata": {},
    "source": [
     "## Phase\n",
@@ -293,43 +293,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "written-preference",
-   "metadata": {
-    "tags": [
-     "remove-input"
-    ]
-   },
+   "id": "processed-attempt",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "if not os.path.exists('/tmp/tutorial-data'):\n",
-    "    os.chdir('/tmp')\n",
-    "    os.system('git clone --depth 1 https://github.com/snowex-hackweek/tutorial-data.git')"
+    "#%%bash \n",
+    "\n",
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "trying-interval",
+   "id": "scientific-health",
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = '/tmp/tutorial-data/sar/S1AA_20201030T131820_20201111T131820_VVP012_INT80_G_ueF_EBD2/S1AA_20201030T131820_20201111T131820_VVP012_INT80_G_ueF_EBD2_unw_phase.tif'\n",
+    "path = '/tmp/tutorial-data/sar/sentinel1/S1AA_20201030T131820_20201111T131820_VVP012_INT80_G_ueF_EBD2/S1AA_20201030T131820_20201111T131820_VVP012_INT80_G_ueF_EBD2_unw_phase.tif'\n",
     "da = rioxarray.open_rasterio(path, masked=True).squeeze('band')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "focused-allocation",
+   "id": "herbal-diving",
    "metadata": {},
    "outputs": [],
    "source": [
-    "da.hvplot.image(x='x', y='y', aspect='equal', rasterize=True, cmap='bwr', title='2020/10/30_2020/11/11 Unwrapped Phase (radians)')"
+    "da.hvplot.image(x='x', y='y', aspect='equal', rasterize=True, cmap='plasma', title='2020/10/30_2020/11/11 Unwrapped Phase (radians)')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bizarre-senate",
+   "id": "native-advocate",
    "metadata": {},
    "source": [
     "```{admonition} Interpretation\n",
@@ -340,7 +345,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "passive-tourism",
+   "id": "signed-header",
    "metadata": {},
    "source": [
     "```{admonition} Exercises\n",
@@ -354,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pretty-isolation",
+   "id": "discrete-motel",
    "metadata": {},
    "source": [
     "## Next steps\n",

--- a/book/tutorials/sar/swesarr.ipynb
+++ b/book/tutorials/sar/swesarr.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "atlantic-trance",
+   "id": "separate-incentive",
    "metadata": {},
    "source": [
     "![NASA](http://www.nasa.gov/sites/all/themes/custom/nasatwo/images/nasa-logo.svg)\n",
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "thirty-report",
+   "id": "adjusted-southeast",
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "optimum-parallel",
+   "id": "hawaiian-activation",
    "metadata": {},
    "source": [
     "# SWESARR Tutorial"
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dietary-sherman",
+   "id": "destroyed-question",
    "metadata": {},
    "source": [
     "## Quick References\n",
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "attended-document",
+   "id": "agreed-mixture",
    "metadata": {},
    "source": [
     "## What is SWESARR?"
@@ -74,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "exceptional-assist",
+   "id": "pressed-mother",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "elder-scenario",
+   "id": "irish-choice",
    "metadata": {},
    "source": [
     "<UL>\n",
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "measured-auction",
+   "id": "statistical-thinking",
    "metadata": {},
    "source": [
     "## Active and Passive? Microwave Remote Sensing?"
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "manufactured-theology",
+   "id": "fifty-workplace",
    "metadata": {},
    "source": [
     "\n",
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "suburban-adjustment",
+   "id": "peaceful-shoot",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "diverse-information",
+   "id": "behind-canberra",
    "metadata": {},
    "source": [
     "## SWESARR Sensors\n",
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "economic-details",
+   "id": "foster-blair",
    "metadata": {},
    "source": [
     "## SWESARR Spatiotemporal Coverage\n",
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "egyptian-outreach",
+   "id": "fancy-roommate",
    "metadata": {},
    "source": [
     "<div>\n",
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "starting-preserve",
+   "id": "numeric-hierarchy",
    "metadata": {},
    "source": [
     "## Reading SWESARR Data\n",
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "wrapped-madonna",
+   "id": "charitable-pierce",
    "metadata": {},
    "source": [
     "<CENTER>\n",
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "strategic-establishment",
+   "id": "endangered-strap",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +283,7 @@
     "\n",
     "import os\n",
     "import sys\n",
-    "sys.path.append(\"./swesarr/helper/\")\n",
+    "sys.path.append(\"./swesarr/util\")\n",
     "\n",
     "from helper import gdal_corners, join_files, join_sar_radiom"
    ]
@@ -291,27 +291,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eastern-opening",
+   "id": "tracked-district",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%%bash \n",
+    "%%bash \n",
     "\n",
-    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
-    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "# Retrieve a copy of data files used in this tutorial from Zenodo.org:\n",
+    "# Re-running this cell will not re-download things if they already exist\n",
     "\n",
-    "#cd /tmp\n",
-    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
-    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
-    "#unzip -n tutorial-data.zip\n",
-    "\n",
-    "# temporary equivalent\n",
-    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+    "mkdir -p /tmp/tutorial-data\n",
+    "cd /tmp/tutorial-data\n",
+    "wget -q -nc -O data.zip https://zenodo.org/record/5504396/files/sar.zip\n",
+    "unzip -q -n data.zip\n",
+    "rm data.zip"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "breathing-cookbook",
+   "id": "religious-speech",
    "metadata": {},
    "source": [
     "#### Select your data"
@@ -320,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "secondary-question",
+   "id": "spanish-chess",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confused-passion",
+   "id": "antique-recorder",
    "metadata": {},
    "source": [
     "#### Download SAR data and place into data folder"
@@ -360,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "thorough-document",
+   "id": "falling-revelation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +384,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "opposite-commonwealth",
+   "id": "racial-cargo",
    "metadata": {},
    "source": [
     "#### Merge SAR datasets into single xarray file"
@@ -395,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cheap-enclosure",
+   "id": "voluntary-malpractice",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sitting-printer",
+   "id": "imported-chart",
    "metadata": {},
    "source": [
     "#### Plot data with hvplot"
@@ -414,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "concrete-nancy",
+   "id": "selective-procedure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +430,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hairy-strip",
+   "id": "fewer-profession",
    "metadata": {},
    "source": [
     "| 🎉 | Congratulations! You now know how to download and display a SWESARR SAR dataset !      | 🎉 |\n",
@@ -442,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adverse-grove",
+   "id": "optimum-excerpt",
    "metadata": {},
    "source": [
     "### Radiometer Data Example"
@@ -450,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ranking-leisure",
+   "id": "human-dover",
    "metadata": {},
    "source": [
     "* SWESARR's radiometer data is publicly available at NSIDC\n",
@@ -461,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "geographic-typing",
+   "id": "assured-brick",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "extraordinary-syracuse",
+   "id": "capital-thong",
    "metadata": {},
    "source": [
     "#### Downloading SWESARR Radiometer Data with `wget`\n",
@@ -500,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "another-network",
+   "id": "structural-persian",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +508,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "tight-somalia",
+   "id": "complimentary-honor",
    "metadata": {},
    "source": [
     "#### Select an example radiometer data file"
@@ -519,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tight-gates",
+   "id": "binary-water",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "first-rubber",
+   "id": "occupational-milan",
    "metadata": {},
    "source": [
     "#### Lets examine the radiometer data files content"
@@ -541,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "advisory-vertex",
+   "id": "romantic-norfolk",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "played-receptor",
+   "id": "architectural-comment",
    "metadata": {},
    "source": [
     "#### Plot radiometer data with hvplot"
@@ -559,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "colored-fishing",
+   "id": "romance-failure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "former-share",
+   "id": "normal-flesh",
    "metadata": {},
    "source": [
     "| 🎉 | Congratulations! You now know how to download and display a SWESARR radiometer dataset !      | 🎉 |\n",
@@ -600,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adverse-fence",
+   "id": "educational-synthetic",
    "metadata": {},
    "source": [
     "## SAR and Radiometer Together"
@@ -608,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "protected-mechanism",
+   "id": "harmful-heading",
    "metadata": {},
    "source": [
     "* The novelty of SWESARR lies in its colocated SAR and radiometer systems\n",
@@ -619,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alpha-oxygen",
+   "id": "direct-trade",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "australian-kuwait",
+   "id": "confirmed-right",
    "metadata": {},
    "source": [
     "## Exercise"
@@ -639,7 +637,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "equipped-toolbox",
+   "id": "graphic-marsh",
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
@@ -661,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "supreme-knitting",
+   "id": "fourth-homework",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -689,7 +687,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "prescription-wesley",
+   "id": "tracked-congress",
    "metadata": {},
    "source": [
     "<br><br><br>\n",

--- a/book/tutorials/sar/swesarr.ipynb
+++ b/book/tutorials/sar/swesarr.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "restricted-produce",
+   "id": "atlantic-trance",
    "metadata": {},
    "source": [
     "![NASA](http://www.nasa.gov/sites/all/themes/custom/nasatwo/images/nasa-logo.svg)\n",
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "maritime-affair",
+   "id": "thirty-report",
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "green-metabolism",
+   "id": "optimum-parallel",
    "metadata": {},
    "source": [
     "# SWESARR Tutorial"
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "recreational-gabriel",
+   "id": "dietary-sherman",
    "metadata": {},
    "source": [
     "## Quick References\n",
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "anonymous-lithuania",
+   "id": "attended-document",
    "metadata": {},
    "source": [
     "## What is SWESARR?"
@@ -74,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "supposed-appreciation",
+   "id": "exceptional-assist",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "outer-knock",
+   "id": "elder-scenario",
    "metadata": {},
    "source": [
     "<UL>\n",
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "swedish-antenna",
+   "id": "measured-auction",
    "metadata": {},
    "source": [
     "## Active and Passive? Microwave Remote Sensing?"
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "jewish-newton",
+   "id": "manufactured-theology",
    "metadata": {},
    "source": [
     "\n",
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "chronic-target",
+   "id": "suburban-adjustment",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "saving-student",
+   "id": "diverse-information",
    "metadata": {},
    "source": [
     "## SWESARR Sensors\n",
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "western-intelligence",
+   "id": "economic-details",
    "metadata": {},
    "source": [
     "## SWESARR Spatiotemporal Coverage\n",
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stunning-gazette",
+   "id": "egyptian-outreach",
    "metadata": {},
    "source": [
     "<div>\n",
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hairy-disposal",
+   "id": "starting-preserve",
    "metadata": {},
    "source": [
     "## Reading SWESARR Data\n",
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "alert-emission",
+   "id": "wrapped-madonna",
    "metadata": {},
    "source": [
     "<CENTER>\n",
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "intellectual-passion",
+   "id": "strategic-establishment",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,17 +283,35 @@
     "\n",
     "import os\n",
     "import sys\n",
-    "\n",
-    "swesarr_subdirs = [\"data\", \"util\"]\n",
-    "tmp = [sys.path.append(os.getcwd() + \"/swesarr/\" + sd) for sd in swesarr_subdirs]\n",
-    "del tmp # suppress Jupyter notebook output, delete variable\n",
+    "sys.path.append(\"./swesarr/helper/\")\n",
     "\n",
     "from helper import gdal_corners, join_files, join_sar_radiom"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eastern-opening",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%%bash \n",
+    "\n",
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "planned-montgomery",
+   "id": "breathing-cookbook",
    "metadata": {},
    "source": [
     "#### Select your data"
@@ -302,12 +320,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "grave-baghdad",
+   "id": "secondary-question",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# select files to download\n",
-    "\n",
+    "TUTORIAL_DATA = '/tmp/tutorial-data/sar/swesarr/'\n",
+    "    \n",
     "# SWESARR data website\n",
     "source_repo = 'https://glihtdata.gsfc.nasa.gov/files/radar/SWESARR/prerelease/'\n",
     "\n",
@@ -327,20 +345,13 @@
     "# store the location of the SAR tiles as they're located on the SWESARR data server\n",
     "remote_tiles = [source_repo + flight_line + d for d in data_files]\n",
     "\n",
-    "# create local output data directory\n",
-    "output_dir = '/tmp/swesarr/data/'\n",
-    "try:\n",
-    "    os.makedirs(output_dir)\n",
-    "except FileExistsError:\n",
-    "    print('output directory prepared!')\n",
-    "\n",
     "# store individual TIF files locally on our computer / server\n",
-    "output_paths = [output_dir + d for d in data_files]"
+    "output_paths = [TUTORIAL_DATA + d for d in data_files]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "junior-butterfly",
+   "id": "confused-passion",
    "metadata": {},
    "source": [
     "#### Download SAR data and place into data folder"
@@ -349,31 +360,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "celtic-lucas",
+   "id": "thorough-document",
    "metadata": {},
    "outputs": [],
    "source": [
-    "##    for each file selected, store the data locally \n",
-    "##\n",
-    "##    only run this block if you want to store data on the current \n",
-    "##    server/hard drive this notebook is located.\n",
-    "##\n",
-    "################################################################\n",
-    "\n",
-    "for remote_tile, output_path in zip(remote_tiles, output_paths):\n",
+    "if not os.path.exists(TUTORIAL_DATA):\n",
     "    \n",
-    "    # download data\n",
-    "    r = requests.get(remote_tile)\n",
+    "    ##    for each file selected, store the data locally \n",
+    "    ##\n",
+    "    ##    only run this block if you want to store data on the current \n",
+    "    ##    server/hard drive this notebook is located.\n",
+    "    ##\n",
+    "    ################################################################\n",
     "\n",
-    "    # Store data (~= 65 MB/file)\n",
-    "    if r.status_code == 200:\n",
-    "        with open(output_path, 'wb') as f:\n",
-    "            f.write(r.content)"
+    "    for remote_tile, output_path in zip(remote_tiles, output_paths):\n",
+    "\n",
+    "        # download data\n",
+    "        r = requests.get(remote_tile)\n",
+    "\n",
+    "        # Store data (~= 65 MB/file)\n",
+    "        if r.status_code == 200:\n",
+    "            with open(output_path, 'wb') as f:\n",
+    "                f.write(r.content)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "posted-immune",
+   "id": "opposite-commonwealth",
    "metadata": {},
    "source": [
     "#### Merge SAR datasets into single xarray file"
@@ -382,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "complete-heading",
+   "id": "cheap-enclosure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +405,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abroad-venture",
+   "id": "sitting-printer",
    "metadata": {},
    "source": [
     "#### Plot data with hvplot"
@@ -401,7 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "suspended-solution",
+   "id": "concrete-nancy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "absent-operator",
+   "id": "hairy-strip",
    "metadata": {},
    "source": [
     "| 🎉 | Congratulations! You now know how to download and display a SWESARR SAR dataset !      | 🎉 |\n",
@@ -429,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fewer-dictionary",
+   "id": "adverse-grove",
    "metadata": {},
    "source": [
     "### Radiometer Data Example"
@@ -437,7 +450,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "frank-channels",
+   "id": "ranking-leisure",
    "metadata": {},
    "source": [
     "* SWESARR's radiometer data is publicly available at NSIDC\n",
@@ -448,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "minor-costume",
+   "id": "geographic-typing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "offensive-consequence",
+   "id": "extraordinary-syracuse",
    "metadata": {},
    "source": [
     "#### Downloading SWESARR Radiometer Data with `wget`\n",
@@ -487,16 +500,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "boxed-steps",
+   "id": "another-network",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget --quiet https://n5eil01u.ecs.nsidc.org/SNOWEX/SNEX20_SWESARR_TB.001/2020.02.11/SNEX20_SWESARR_TB_GRMCT2_13801_20007_000_200211_XKKa225H_v01.csv -O {output_dir}/SNEX20_SWESARR_TB_GRMCT2_13801_20007_000_200211_XKuKa225H_v03.csv"
+    "# To get orginial data from NSIDC\n",
+    "#!wget --quiet https://n5eil01u.ecs.nsidc.org/SNOWEX/SNEX20_SWESARR_TB.001/2020.02.11/SNEX20_SWESARR_TB_GRMCT2_13801_20007_000_200211_XKKa225H_v01.csv -O {output_dir}/SNEX20_SWESARR_TB_GRMCT2_13801_20007_000_200211_XKuKa225H_v03.csv"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "seasonal-capture",
+   "id": "tight-somalia",
    "metadata": {},
    "source": [
     "#### Select an example radiometer data file"
@@ -505,12 +519,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acquired-questionnaire",
+   "id": "tight-gates",
    "metadata": {},
    "outputs": [],
    "source": [
     "# use the file we downloaded with wget above\n",
-    "excel_path = f'{output_dir}/SNEX20_SWESARR_TB_GRMCT2_13801_20007_000_200211_XKuKa225H_v03.csv'\n",
+    "excel_path = f'{TUTORIAL_DATA}/SNEX20_SWESARR_TB_GRMCT2_13801_20007_000_200211_XKuKa225H_v03.csv'\n",
     "\n",
     "# read data\n",
     "radiom = pd.read_csv(excel_path)"
@@ -518,7 +532,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "raising-hebrew",
+   "id": "first-rubber",
    "metadata": {},
    "source": [
     "#### Lets examine the radiometer data files content"
@@ -527,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "latest-kingdom",
+   "id": "advisory-vertex",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +550,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "overall-state",
+   "id": "played-receptor",
    "metadata": {},
    "source": [
     "#### Plot radiometer data with hvplot"
@@ -545,7 +559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dirty-still",
+   "id": "colored-fishing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +591,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "velvet-dressing",
+   "id": "former-share",
    "metadata": {},
    "source": [
     "| 🎉 | Congratulations! You now know how to download and display a SWESARR radiometer dataset !      | 🎉 |\n",
@@ -586,7 +600,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "original-banks",
+   "id": "adverse-fence",
    "metadata": {},
    "source": [
     "## SAR and Radiometer Together"
@@ -594,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "distinct-pitch",
+   "id": "protected-mechanism",
    "metadata": {},
    "source": [
     "* The novelty of SWESARR lies in its colocated SAR and radiometer systems\n",
@@ -605,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "imported-exploration",
+   "id": "alpha-oxygen",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confident-quarter",
+   "id": "australian-kuwait",
    "metadata": {},
    "source": [
     "## Exercise"
@@ -625,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bibliographic-convention",
+   "id": "equipped-toolbox",
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
@@ -647,7 +661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "worth-swiss",
+   "id": "supreme-knitting",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "employed-variance",
+   "id": "prescription-wesley",
    "metadata": {},
    "source": [
     "<br><br><br>\n",
@@ -684,14 +698,6 @@
     "<b>Interpreting Data:</b> After the 2019 and 2020 measurement periods for SWESARR, an internal timing error was found in the flight data which affects the spatial precision of the measurements. While we are working to correct this geospatial error, please consider this offset before drawing conclusions from SWESARR data if you are using a dataset prior to this correction. The SWESARR website will announce the update of the geospatially corrected dataset.\n",
     "</div>\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "equal-brunei",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/book/tutorials/sar/uavsar.ipynb
+++ b/book/tutorials/sar/uavsar.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "municipal-certification",
+   "id": "organic-tomato",
    "metadata": {},
    "source": [
     "# UAVSAR\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "derived-equilibrium",
+   "id": "electrical-failure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "naked-county",
+   "id": "everyday-portfolio",
    "metadata": {},
    "source": [
     "## What is UAVSAR?\n",
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dental-interval",
+   "id": "outside-given",
    "metadata": {},
    "source": [
     "## NASA SnowEx 2020 and 2021 UAVSAR Campaings\n",
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "modified-envelope",
+   "id": "organizational-graham",
    "metadata": {},
    "source": [
     "## Data Access\n",
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "modern-stewart",
+   "id": "minute-grain",
    "metadata": {},
    "source": [
     "```{admonition} InSAR Data Types\n",
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "protecting-creature",
+   "id": "disciplinary-precipitation",
    "metadata": {},
    "source": [
     "### Data Download\n",
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sustainable-courage",
+   "id": "brazilian-artwork",
    "metadata": {},
    "source": [
     ":::{figure-md} vertex\n",
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "monetary-package",
+   "id": "tight-activation",
    "metadata": {},
    "source": [
     ":::{note}\n",
@@ -144,28 +144,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "occupational-occasions",
+   "id": "authorized-navigator",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%%bash \n",
+    "%%bash \n",
     "\n",
-    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
-    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "# Retrieve a copy of data files used in this tutorial from Zenodo.org:\n",
+    "# Re-running this cell will not re-download things if they already exist\n",
     "\n",
-    "#cd /tmp\n",
-    "#wget -nc -q https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
-    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
-    "#unzip -n tutorial-data.zip\n",
-    "\n",
-    "# temporary equivalent\n",
-    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+    "mkdir -p /tmp/tutorial-data\n",
+    "cd /tmp/tutorial-data\n",
+    "wget -q -nc -O data.zip https://zenodo.org/record/5504396/files/sar.zip\n",
+    "unzip -q -n data.zip\n",
+    "rm data.zip"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "liable-paste",
+   "id": "alleged-breeding",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "reverse-stick",
+   "id": "desperate-commissioner",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "generic-afghanistan",
+   "id": "precious-pencil",
    "metadata": {},
    "source": [
     "Inspect the meta data the rasters using the rio (shorthand for rasterio) ```profile``` function."
@@ -214,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ecological-argentina",
+   "id": "intensive-facility",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lonely-albany",
+   "id": "developmental-sigma",
    "metadata": {},
    "source": [
     "## Opening and plotting the raw UAVSAR raster files\n",
@@ -236,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bronze-locking",
+   "id": "arabic-benefit",
    "metadata": {},
    "source": [
     "### Amp 1"
@@ -245,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "foreign-individual",
+   "id": "organized-softball",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "compatible-caribbean",
+   "id": "cathedral-feeling",
    "metadata": {},
    "source": [
     "### Amp 2"
@@ -266,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "negative-ozone",
+   "id": "czech-hampton",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "incident-implement",
+   "id": "perfect-founder",
    "metadata": {},
    "source": [
     "### Coherence"
@@ -287,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "postal-positive",
+   "id": "built-boundary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hourly-promise",
+   "id": "confident-screening",
    "metadata": {},
    "source": [
     "### DEM\n",
@@ -309,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iraqi-intervention",
+   "id": "other-croatia",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "activated-humor",
+   "id": "sweet-trauma",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "excited-defense",
+   "id": "indirect-amino",
    "metadata": {},
    "source": [
     "### Unwrapped Phase\n",
@@ -341,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "artificial-cannon",
+   "id": "proved-seeker",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "golden-survivor",
+   "id": "final-interval",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +362,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "special-newport",
+   "id": "endangered-silly",
    "metadata": {},
    "source": [
     "## Formatting the data for visualization\n",
@@ -373,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "overall-communist",
+   "id": "asian-distinction",
    "metadata": {},
    "source": [
     "### Amplitude formatting\n",
@@ -383,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fancy-cemetery",
+   "id": "medical-wayne",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "colored-bulletin",
+   "id": "moral-warner",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fixed-response",
+   "id": "grave-karma",
    "metadata": {},
    "source": [
     "Instead of using the ```rio.show()``` function, we'll try out the ```matplotlib``` (we are calling ```plt```) ```im.show()``` style of plotting to implement a color scale."
@@ -428,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "trained-despite",
+   "id": "invalid-aerospace",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "official-china",
+   "id": "atmospheric-annotation",
    "metadata": {},
    "source": [
     "Now we'll create a function called ```show_two_images()``` to plot two images at once. The function inputs are a data array, color map name, and a plot title for both images. It uses ```np.nanpercentile()``` to automatically set the color scale bounds, but you can also set them manually."
@@ -453,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "supported-absolute",
+   "id": "artistic-vector",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -498,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "subsequent-nitrogen",
+   "id": "fallen-sociology",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mathematical-cream",
+   "id": "laughing-greensboro",
    "metadata": {},
    "source": [
     "### Coherence, Unwrapped Phase, DEM\n",
@@ -519,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "organizational-cradle",
+   "id": "vocal-apartment",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "alert-turkey",
+   "id": "complimentary-finland",
    "metadata": {},
    "source": [
     "Checking to see if it worked by comparing ```unw_rast``` which still includes 0's to ```unw_array``` where we changed them to NaN."
@@ -552,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "focused-brighton",
+   "id": "measured-angel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "allied-location",
+   "id": "elementary-trinidad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +571,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "multiple-controversy",
+   "id": "considered-destruction",
    "metadata": {},
    "source": [
     "Let's plot the UNW raster larger so we can get a better look at the detail."
@@ -582,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "rising-headset",
+   "id": "level-death",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "shared-alpha",
+   "id": "permanent-feedback",
    "metadata": {},
    "source": [
     " This looks **much** better! Plotting the image at a larger scale allows us to see an accurate representation of the data."
@@ -609,7 +607,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "frank-earth",
+   "id": "amateur-commonwealth",
    "metadata": {},
    "source": [
     "## LiDAR depth change vs InSAR Phase change Comparison\n",
@@ -619,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "humanitarian-prompt",
+   "id": "english-auditor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -633,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fifty-visibility",
+   "id": "confident-portal",
    "metadata": {},
    "source": [
     "We can see this raster has a no data value of ```'nodata': -3.4e+38``` set (most of the UAVSAR ones did not). Therefore we can read it in with the ```masked=TRUE``` command to automatically mask out the no data pixels."
@@ -642,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "modern-fraud",
+   "id": "functional-porter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "developing-brief",
+   "id": "different-football",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +663,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "continuous-atlanta",
+   "id": "verbal-kernel",
    "metadata": {},
    "source": [
     "## LiDAR vs UNW\n",
@@ -675,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "varied-result",
+   "id": "external-amsterdam",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +682,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "peaceful-judgment",
+   "id": "chemical-hughes",
    "metadata": {},
    "source": [
     "The two rasters cover different areas, are different resolutions, and have different missing pixels. Let's zoom into the top left corner of Grand Mesa where there was significant wind drifting to compare the two data sets."
@@ -693,7 +691,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "electrical-thought",
+   "id": "removed-thesaurus",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acquired-charter",
+   "id": "documented-forth",
    "metadata": {},
    "source": [
     "As you can see in the two plots above, there is a very strong spatial relationship between LiDAR depth change and InSAR change in phase. This relationship is the basis of measuring changes in SWE using L-band InSAR. While we don't get into the next step of converting phase change to SWE or depth change from InSAR, we will get into that in the UAVSAR project!"

--- a/book/tutorials/sar/uavsar.ipynb
+++ b/book/tutorials/sar/uavsar.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cathedral-killing",
+   "id": "municipal-certification",
    "metadata": {},
    "source": [
     "# UAVSAR\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "universal-detroit",
+   "id": "derived-equilibrium",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "quarterly-motor",
+   "id": "naked-county",
    "metadata": {},
    "source": [
     "## What is UAVSAR?\n",
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "light-perfume",
+   "id": "dental-interval",
    "metadata": {},
    "source": [
     "## NASA SnowEx 2020 and 2021 UAVSAR Campaings\n",
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "separated-prefix",
+   "id": "modified-envelope",
    "metadata": {},
    "source": [
     "## Data Access\n",
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "uniform-western",
+   "id": "modern-stewart",
    "metadata": {},
    "source": [
     "```{admonition} InSAR Data Types\n",
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "clear-bumper",
+   "id": "protecting-creature",
    "metadata": {},
    "source": [
     "### Data Download\n",
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "steady-lingerie",
+   "id": "sustainable-courage",
    "metadata": {},
    "source": [
     ":::{figure-md} vertex\n",
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eleven-tower",
+   "id": "monetary-package",
    "metadata": {},
    "source": [
     ":::{note}\n",
@@ -144,20 +144,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "perfect-vitamin",
+   "id": "occupational-occasions",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Change to tmp directory and download staged tutorial data\n",
-    "os.chdir('/tmp')\n",
+    "#%%bash \n",
     "\n",
-    "!aws s3 cp --no-progress s3://snowex-data/tutorial-data/sar/uavsar/ .  --recursive --exclude \"*\" --include \"*tiff\""
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc -q https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "civic-bennett",
+   "id": "liable-paste",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change to tmp directory and download staged tutorial data\n",
+    "os.chdir('/tmp/tutorial-data/sar/uavsar/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "reverse-stick",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "atomic-bride",
+   "id": "generic-afghanistan",
    "metadata": {},
    "source": [
     "Inspect the meta data the rasters using the rio (shorthand for rasterio) ```profile``` function."
@@ -195,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "integral-village",
+   "id": "ecological-argentina",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vocal-police",
+   "id": "lonely-albany",
    "metadata": {},
    "source": [
     "## Opening and plotting the raw UAVSAR raster files\n",
@@ -217,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "promotional-encoding",
+   "id": "bronze-locking",
    "metadata": {},
    "source": [
     "### Amp 1"
@@ -226,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "banner-enough",
+   "id": "foreign-individual",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +257,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "controversial-gravity",
+   "id": "compatible-caribbean",
    "metadata": {},
    "source": [
     "### Amp 2"
@@ -247,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "personalized-daily",
+   "id": "negative-ozone",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "inclusive-board",
+   "id": "incident-implement",
    "metadata": {},
    "source": [
     "### Coherence"
@@ -268,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "thirty-potter",
+   "id": "postal-positive",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vocal-terminal",
+   "id": "hourly-promise",
    "metadata": {},
    "source": [
     "### DEM\n",
@@ -290,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "activated-pennsylvania",
+   "id": "iraqi-intervention",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pleased-techno",
+   "id": "activated-humor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "necessary-brick",
+   "id": "excited-defense",
    "metadata": {},
    "source": [
     "### Unwrapped Phase\n",
@@ -322,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "regulated-mileage",
+   "id": "artificial-cannon",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "forced-aspect",
+   "id": "golden-survivor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "consolidated-wyoming",
+   "id": "special-newport",
    "metadata": {},
    "source": [
     "## Formatting the data for visualization\n",
@@ -354,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "returning-floating",
+   "id": "overall-communist",
    "metadata": {},
    "source": [
     "### Amplitude formatting\n",
@@ -364,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "related-copying",
+   "id": "fancy-cemetery",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "endless-paris",
+   "id": "colored-bulletin",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "international-edgar",
+   "id": "fixed-response",
    "metadata": {},
    "source": [
     "Instead of using the ```rio.show()``` function, we'll try out the ```matplotlib``` (we are calling ```plt```) ```im.show()``` style of plotting to implement a color scale."
@@ -409,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "overhead-carbon",
+   "id": "trained-despite",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "experienced-reply",
+   "id": "official-china",
    "metadata": {},
    "source": [
     "Now we'll create a function called ```show_two_images()``` to plot two images at once. The function inputs are a data array, color map name, and a plot title for both images. It uses ```np.nanpercentile()``` to automatically set the color scale bounds, but you can also set them manually."
@@ -434,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "unnecessary-height",
+   "id": "supported-absolute",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "selective-gross",
+   "id": "subsequent-nitrogen",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "helpful-westminster",
+   "id": "mathematical-cream",
    "metadata": {},
    "source": [
     "### Coherence, Unwrapped Phase, DEM\n",
@@ -500,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sapphire-rover",
+   "id": "organizational-cradle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +543,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "handed-default",
+   "id": "alert-turkey",
    "metadata": {},
    "source": [
     "Checking to see if it worked by comparing ```unw_rast``` which still includes 0's to ```unw_array``` where we changed them to NaN."
@@ -533,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sharing-attraction",
+   "id": "focused-brighton",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "banned-chassis",
+   "id": "allied-location",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "altered-brown",
+   "id": "multiple-controversy",
    "metadata": {},
    "source": [
     "Let's plot the UNW raster larger so we can get a better look at the detail."
@@ -563,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "figured-capitol",
+   "id": "rising-headset",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unlike-headquarters",
+   "id": "shared-alpha",
    "metadata": {},
    "source": [
     " This looks **much** better! Plotting the image at a larger scale allows us to see an accurate representation of the data."
@@ -590,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "equivalent-handbook",
+   "id": "frank-earth",
    "metadata": {},
    "source": [
     "## LiDAR depth change vs InSAR Phase change Comparison\n",
@@ -600,21 +619,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "suburban-bread",
+   "id": "humanitarian-prompt",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!aws s3 cp --no-progress s3://snowex-data/tutorial-data/sar/gmesa_depth_change_02-01_02-13.tif /tmp/gmesa_depth_change_02-01_02-13.tif"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "royal-hacker",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lidar_dc = '/tmp/gmesa_depth_change_02-01_02-13.tif' #path to lidar depth change raster\n",
+    "lidar_dc = '/tmp/tutorial-data/sar/uavsar/gmesa_depth_change_02-01_02-13.tif' #path to lidar depth change raster\n",
     "\n",
     "# print meta data, and check to see if the raster has a no data value\n",
     "lidar_rast = rio.open(lidar_dc)\n",
@@ -624,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "forbidden-focus",
+   "id": "fifty-visibility",
    "metadata": {},
    "source": [
     "We can see this raster has a no data value of ```'nodata': -3.4e+38``` set (most of the UAVSAR ones did not). Therefore we can read it in with the ```masked=TRUE``` command to automatically mask out the no data pixels."
@@ -633,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "educated-preference",
+   "id": "modern-fraud",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "billion-attention",
+   "id": "developing-brief",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "proper-internet",
+   "id": "continuous-atlanta",
    "metadata": {},
    "source": [
     "## LiDAR vs UNW\n",
@@ -666,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stuffed-specific",
+   "id": "varied-result",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "proud-occurrence",
+   "id": "peaceful-judgment",
    "metadata": {},
    "source": [
     "The two rasters cover different areas, are different resolutions, and have different missing pixels. Let's zoom into the top left corner of Grand Mesa where there was significant wind drifting to compare the two data sets."
@@ -684,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "norwegian-taxation",
+   "id": "electrical-thought",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,7 +703,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "equal-comfort",
+   "id": "acquired-charter",
    "metadata": {},
    "source": [
     "As you can see in the two plots above, there is a very strong spatial relationship between LiDAR depth change and InSAR change in phase. This relationship is the basis of measuring changes in SWE using L-band InSAR. While we don't get into the next step of converting phase change to SWE or depth change from InSAR, we will get into that in the UAVSAR project!"

--- a/book/tutorials/thermal-ir/thermal-ir-data-download.ipynb
+++ b/book/tutorials/thermal-ir/thermal-ir-data-download.ipynb
@@ -2,16 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cooperative-question",
+   "id": "saving-fellow",
    "metadata": {},
    "source": [
     "# Downloading datasets for the thermal IR tutorial\n",
     "\n",
     "This is an optional notebook to demonstrate a method for accessing SnowEx data through the NASA EarthData API. \n",
-    "\n",
-    "Alternatively (as seen within the [thermal-ir-tutorial.ipynb](thermal-ir-tutorial.ipynb) notebook) you can access all data needed for the tutorial by running the following command in a terminal:\n",
-    "\n",
-    "`aws s3 sync --quiet s3://snowex-data/tutorial-data/thermal-ir/ /tmp/thermal-ir/`\n",
     "\n",
     ":::{admonition} Learning Objectives\n",
     "\n",
@@ -25,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mediterranean-diagnosis",
+   "id": "outer-defeat",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hundred-figure",
+   "id": "sweet-newfoundland",
    "metadata": {},
    "source": [
     "We are going to use a custom function (`earthdata_api.earthdata_granule_search()`) which can return a list of download URLs for files we search for. We can then use a utility like wget (with our EarthData credentials) to download the files from that list of URLs. \n",
@@ -46,7 +42,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "valuable-baker",
+   "id": "pacific-raleigh",
    "metadata": {},
    "source": [
     "**First, set up some of the search parameters we'll use for all the datasets we want to find:**\n",
@@ -56,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vulnerable-drawing",
+   "id": "vocal-setting",
    "metadata": {},
    "source": [
     "When defining a bounding box for the study area we want to look at, Earthdata will return anything that overlaps this spot.\n",
@@ -69,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "auburn-repository",
+   "id": "lonely-grave",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "serious-kenya",
+   "id": "incident-perth",
    "metadata": {},
    "source": [
     "We are going to look at one specific day, but we could search multiple dates/times. Those dates/times don't need to be a continuous time period, we could instead provide a list of dates/times. (That was my original motivation to write this function). Use either [pandas.Timestamp](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html), [datetime.datetime](https://docs.python.org/3/library/datetime.html#datetime.datetime), or [numpy.datetime64](https://numpy.org/doc/stable/reference/arrays.datetime.html) objects."
@@ -87,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "consecutive-arbor",
+   "id": "willing-cyprus",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "angry-guidance",
+   "id": "sized-producer",
    "metadata": {},
    "source": [
     "---\n",
@@ -108,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "waiting-nature",
+   "id": "armed-drilling",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "automotive-mailing",
+   "id": "vital-image",
    "metadata": {},
    "source": [
     "To make sure we find the images from this day, we need to specify a window in time to search, which starts at our `timestampsUTC` time we already defined.\n",
@@ -131,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "assumed-internship",
+   "id": "independent-veteran",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "incoming-boston",
+   "id": "bright-battlefield",
    "metadata": {},
    "source": [
     "We also want to save the list of data access URLs so we can use wget to download them"
@@ -150,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "indie-township",
+   "id": "motivated-sierra",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "angry-accused",
+   "id": "departmental-action",
    "metadata": {},
    "source": [
     "**Finally, make the API call to get the list of files that match our search**"
@@ -172,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "temporal-fighter",
+   "id": "collaborative-frame",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confident-packet",
+   "id": "reduced-tongue",
    "metadata": {},
    "source": [
     "**Now we can open a terminal and use wget to download the files that are listed.**\n",
@@ -202,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "martial-casino",
+   "id": "complete-rolling",
    "metadata": {},
    "source": [
     "**Convert hdf to geotiffs with ASTERL1T_hdf2tir.py script.** When we run this utility, the output data will be at-sensor radiance stored as Digital Numbers (DN) as uint16 data types.\n",
@@ -223,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "recovered-religious",
+   "id": "voluntary-removal",
    "metadata": {},
    "source": [
     "---\n",
@@ -234,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "prerequisite-possible",
+   "id": "respective-least",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "responsible-collective",
+   "id": "needed-catalyst",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "chief-logan",
+   "id": "variable-paint",
    "metadata": {},
    "source": [
     "**Use wget to download these data**\n",
@@ -269,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "accessory-platform",
+   "id": "prospective-ghana",
    "metadata": {},
    "source": [
     "Then unzip the folder we just downloaded (`-q` for \"quiet mode\" so it doesn't list every file as it unzips them, `-d` for the directory we want to unzip the files into)\n",
@@ -285,30 +281,39 @@
   },
   {
    "cell_type": "markdown",
-   "id": "powerful-merchandise",
+   "id": "graduate-somewhere",
    "metadata": {},
    "source": [
     "```{warning} Note:\n",
     "The airborne TIR imagery from SnowEx 2020 is not yet publicly available through NSIDC, we will work with a sample image provided in this tutorial.\n",
-    "```\n",
-    "\n",
-    "An alternate method for re-formatting the airborne IR mosaic NetCDF files is below. (You must first download the sample file with `aws s3 sync --quiet s3://snowex-data/tutorial-data/thermal-ir/ /tmp/thermal-ir/` in the terminal)"
+    "```"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "appointed-stress",
+   "id": "choice-marks",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!aws s3 sync --quiet s3://snowex-data/tutorial-data/thermal-ir/ /tmp/thermal-ir/"
+    "#%%bash \n",
+    "\n",
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "italian-female",
+   "id": "demanding-perth",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "spatial-gregory",
+   "id": "outside-tooth",
    "metadata": {},
    "source": [
     "Open an airborne TIR mosaic NetCDF file"
@@ -328,18 +333,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "comparative-provincial",
+   "id": "covered-dakota",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Open airborne TIR mosaic NetCDF file\n",
-    "ds = xr.open_dataset('/tmp/thermal-ir/SNOWEX2020_IR_PLANE_2020Feb08_mosaicked_APLUW.nc',\n",
+    "ds = xr.open_dataset('/tmp/tutorial-data/thermal-ir/SNOWEX2020_IR_PLANE_2020Feb08_mosaicked_APLUW.nc',\n",
     "                     decode_times=False) # set decode_times to False"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "coordinate-portable",
+   "id": "portuguese-trace",
    "metadata": {},
    "source": [
     "Inspect the dataset and its dimensions"
@@ -348,7 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "southwest-finding",
+   "id": "lyric-fault",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "yellow-factory",
+   "id": "increased-render",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "synthetic-handbook",
+   "id": "arbitrary-moscow",
    "metadata": {},
    "source": [
     "There is an extra dimension (\"na\") that we will want to drop, we will want to rename some of the dims, assign coordinates to those dims, and add a coordinate reference system for plotting."
@@ -378,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sophisticated-plane",
+   "id": "stable-pillow",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +395,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "written-plate",
+   "id": "vanilla-referral",
    "metadata": {},
    "source": [
     "Rename the dimensions to some easier to use names"
@@ -399,7 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lovely-candidate",
+   "id": "built-threshold",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "thermal-kazakhstan",
+   "id": "surgical-division",
    "metadata": {},
    "source": [
     "This NetCDF file was generated in MATLAB, and the dates/times are in an epoch format. Use [utcfromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) and [isoformat()](https://docs.python.org/3/library/datetime.html#datetime.date.isoformat) to convert and reformat into a more convenient format."
@@ -420,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "guilty-correction",
+   "id": "cheap-marsh",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dressed-rescue",
+   "id": "raising-sleeve",
    "metadata": {},
    "source": [
     "Assign and then transpose coordinates in our dataset"
@@ -439,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accessible-search",
+   "id": "exclusive-scott",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "first-remains",
+   "id": "possible-country",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +465,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pregnant-paris",
+   "id": "combined-priority",
    "metadata": {},
    "source": [
     "Set spatial dimensions then define which coordinate reference system the spatial dimensions are in"
@@ -469,41 +474,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "senior-detector",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set spatial dimensions with rioxarray\n",
-    "ds.rio.set_spatial_dims('easting', 'northing', inplace=True);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "induced-institution",
+   "id": "nonprofit-culture",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Write the coordinate reference system for the spatial dims with rioxarray\n",
-    "ds.rio.write_crs('epsg:32612', inplace=True);"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "electronic-keeping",
-   "metadata": {},
-   "source": [
-    "Inspect the final, re-formatted dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "operational-utilization",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds"
+    "# https://github.com/corteva/rioxarray/issues/379\n",
+    "ds.rio.write_crs('epsg:32612', inplace=True,\n",
+    "                ).rio.set_spatial_dims('easting', 'northing', inplace=True,\n",
+    "                                      ).rio.write_coordinate_system(inplace=True)"
    ]
   }
  ],

--- a/book/tutorials/thermal-ir/thermal-ir-tutorial.ipynb
+++ b/book/tutorials/thermal-ir/thermal-ir-tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "demonstrated-sweet",
+   "id": "detailed-amber",
    "metadata": {},
    "source": [
     "# Thermal Infrared Remote Sensing of Snow\n",
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "broken-singapore",
+   "id": "banner-brief",
    "metadata": {},
    "source": [
     "**Download the sample datasets for this tutorial**\n",
@@ -30,27 +30,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "front-federal",
+   "id": "utility-thinking",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%%bash \n",
+    "%%bash \n",
     "\n",
-    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
-    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "# Retrieve a copy of data files used in this tutorial from Zenodo.org:\n",
+    "# Re-running this cell will not re-download things if they already exist\n",
     "\n",
-    "#cd /tmp\n",
-    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
-    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
-    "#unzip -n tutorial-data.zip\n",
-    "\n",
-    "# temporary equivalent\n",
-    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
+    "mkdir -p /tmp/tutorial-data\n",
+    "cd /tmp/tutorial-data\n",
+    "wget -q -nc -O data.zip https://zenodo.org/record/5504396/files/thermal-ir.zip\n",
+    "unzip -q -n data.zip\n",
+    "rm data.zip"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "empty-swing",
+   "id": "silent-fighter",
    "metadata": {},
    "source": [
     "**Import the packages we'll need for this tutorial**"
@@ -59,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incorrect-premises",
+   "id": "living-wallet",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "distant-income",
+   "id": "capable-jacob",
    "metadata": {},
    "source": [
     "---\n",
@@ -102,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sized-plenty",
+   "id": "provincial-alaska",
    "metadata": {},
    "source": [
     "Load IR image mosaic geotiff file"
@@ -111,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "musical-matthew",
+   "id": "assisted-middle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "boxed-plymouth",
+   "id": "generic-serum",
    "metadata": {},
    "source": [
     "Inspect the contents of the file we just opened"
@@ -130,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "graphic-wrapping",
+   "id": "excellent-hypothesis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "regional-angel",
+   "id": "sharing-tournament",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stock-welsh",
+   "id": "several-absence",
    "metadata": {},
    "source": [
     "Under the dataarray's attributes we can see that we have a coordinate reference system already defined (crs) as [EPSG:32612](https://epsg.io/32612). We can also find this through `da.rio.crs`. \n",
@@ -160,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "suffering-surfing",
+   "id": "ignored-nutrition",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alone-banking",
+   "id": "boolean-netscape",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "deluxe-visiting",
+   "id": "southern-mailing",
    "metadata": {},
    "source": [
     "Next, the filename shows us when this imagery was taken in UTC time, \"2020-02-08T181915\"\n",
@@ -190,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "backed-concord",
+   "id": "specified-orchestra",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "future-anxiety",
+   "id": "saving-pound",
    "metadata": {},
    "source": [
     "::::{admonition} What color scale should we use for temperature?\n",
@@ -221,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "geological-immune",
+   "id": "mechanical-facing",
    "metadata": {},
    "source": [
     "Plot the airborne TIR image. \n",
@@ -232,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ranging-lebanon",
+   "id": "angry-investigation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +250,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confirmed-anthony",
+   "id": "existing-strip",
    "metadata": {},
    "source": [
     ":::{admonition} Image interpretation\n",
@@ -270,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "educated-integrity",
+   "id": "received-german",
    "metadata": {},
    "source": [
     "## Bonus activity:\n",
@@ -280,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "continental-wallpaper",
+   "id": "bound-badge",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "right-federal",
+   "id": "national-infrared",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "interim-covering",
+   "id": "clear-neighborhood",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "educational-recommendation",
+   "id": "racial-projector",
    "metadata": {},
    "source": [
     "Plot the visible and infrared images side by side. This time, we will change the x and y axes limits ([set_xlim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlim.html), and [set_ylim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_ylim.html)) to zoom in closer."
@@ -321,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "czech-fiber",
+   "id": "geographic-oxford",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "closing-publisher",
+   "id": "palestinian-treasure",
    "metadata": {},
    "source": [
     ":::{admonition} Image interpretation\n",
@@ -367,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "municipal-television",
+   "id": "mineral-aviation",
    "metadata": {},
    "source": [
     "---\n",
@@ -400,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "contrary-authorization",
+   "id": "broke-native",
    "metadata": {},
    "source": [
     "**Where is snow pit 2S10?**\n",
@@ -411,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "satellite-collins",
+   "id": "supreme-madness",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "chubby-browser",
+   "id": "accepted-religion",
    "metadata": {},
    "source": [
     "Then, query [SiteData](https://snowexsql.readthedocs.io/en/latest/database_structure.html#sites-table) using [filter_by](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.filter_by) to find the entry with the site ID that we want (2S10). Preview the resulting geodataframe."
@@ -432,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "angry-stroke",
+   "id": "norman-theater",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "willing-beast",
+   "id": "intermediate-glucose",
    "metadata": {},
    "source": [
     "Inspect of the geodatframe's metadata"
@@ -457,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nominated-system",
+   "id": "smart-tactics",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "positive-stuff",
+   "id": "loved-bradford",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "light-easter",
+   "id": "compound-semester",
    "metadata": {},
    "source": [
     "We can now plot our snow pit site from this [geodataframe](https://geopandas.org/docs/reference/api/geopandas.GeoDataFrame.plot.html) on top of the airborne IR image. (See more tips about plotting geodataframes [here](https://www.earthdatascience.org/courses/scientists-guide-to-plotting-data-in-python/plot-spatial-data/customize-vector-plots/python-change-spatial-extent-of-map-matplotlib-geopandas/))\n",
@@ -488,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lovely-russell",
+   "id": "regional-museum",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +514,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sexual-request",
+   "id": "brave-friday",
    "metadata": {},
    "source": [
     "Change the x and y axes limits ([set_xlim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlim.html), and [set_ylim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_ylim.html)) to zoom in to our point of interest. In this case we can use [df.geometry.total_bounds](https://geopandas.readthedocs.io/en/latest/docs/reference/api/geopandas.GeoSeries.total_bounds.html) to get the x and y values that define the area our geometry takes up. (In this case we have a point so it will return just the point's location, but this would work if we had a polygon as well)"
@@ -525,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "standard-capitol",
+   "id": "regulation-evolution",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +552,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "proprietary-trading",
+   "id": "southeast-tolerance",
    "metadata": {},
    "source": [
     "**Import the snow temperature timeseries dataset**\n",
@@ -567,7 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "thorough-camping",
+   "id": "racial-blade",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +574,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "intensive-simple",
+   "id": "destroyed-unknown",
    "metadata": {},
    "source": [
     "Create a list of column headers according to the readme above (for \"GM1\" which we can read was the datalogger at snowpit 2S10)"
@@ -585,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "median-civilization",
+   "id": "wrapped-portuguese",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,7 +601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "greek-craps",
+   "id": "accessory-robinson",
    "metadata": {},
    "source": [
     "Open the file as a pandas data frame with [read_csv](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html)"
@@ -612,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "universal-auckland",
+   "id": "precise-webster",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +623,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "educated-control",
+   "id": "invalid-capacity",
    "metadata": {},
    "source": [
     "We need to do some formatting of the data fields, but we can preview what we just loaded fist"
@@ -634,7 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "altered-durham",
+   "id": "early-scanning",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -643,7 +641,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adjacent-small",
+   "id": "wound-entry",
    "metadata": {},
    "source": [
     "Data cleanup and formatting"
@@ -652,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "voluntary-isaac",
+   "id": "steady-thermal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,7 +667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "signal-integration",
+   "id": "pretty-southwest",
    "metadata": {},
    "source": [
     "This function lets us convert year and day of year (the format that the datalogger uses) to a pandas [datetime index](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DatetimeIndex.html):"
@@ -678,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "blocked-timing",
+   "id": "joined-pollution",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "approved-socket",
+   "id": "honest-oliver",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -719,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confident-astrology",
+   "id": "hindu-immunology",
    "metadata": {},
    "source": [
     "Inspect the contents"
@@ -728,7 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "automotive-combining",
+   "id": "familiar-applicant",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,7 +735,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "great-inflation",
+   "id": "solved-major",
    "metadata": {},
    "source": [
     "Make a simple plot of the data. We are interested in the variable `rad_avg` which is the average temperature measured by the radiometer over each 5 minute period."
@@ -746,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "native-ranking",
+   "id": "right-driving",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -776,7 +774,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fifth-tournament",
+   "id": "representative-admission",
    "metadata": {},
    "source": [
     ":::{admonition} Bonus plot: look at snow temperatures below the snow surface\n",
@@ -798,7 +796,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stuffed-registrar",
+   "id": "aggressive-capture",
    "metadata": {},
    "source": [
     "But then we want to focus on the date/time when our IR image was from, so zoom in on Feb 8th by changing our plot's [xlim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlim.html) (using pandas [Timestamps](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html) for the x axis values).\n"
@@ -807,7 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "particular-victim",
+   "id": "finished-bronze",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -836,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "occasional-howard",
+   "id": "happy-dispute",
    "metadata": {},
    "source": [
     "---\n",
@@ -851,7 +849,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "together-baking",
+   "id": "bulgarian-invasion",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +862,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "extreme-frank",
+   "id": "widespread-craft",
    "metadata": {},
    "source": [
     "Our result is a DataArray with a single data value at one set of x and y coordinates.\n",
@@ -882,7 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "descending-firmware",
+   "id": "roman-istanbul",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,7 +895,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "brilliant-lincoln",
+   "id": "bronze-person",
    "metadata": {},
    "source": [
     "What does this polygon look like when we plot it on top of the airborne IR image now?"
@@ -906,7 +904,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "latter-syntax",
+   "id": "prostate-virgin",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -937,7 +935,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "statistical-shoot",
+   "id": "centered-novel",
    "metadata": {},
    "source": [
     "Clip the airborne IR raster again, now with our 200 m diameter polygon around the snow pit site."
@@ -946,7 +944,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "practical-candy",
+   "id": "civil-martin",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -959,7 +957,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confident-settlement",
+   "id": "sudden-method",
    "metadata": {},
    "source": [
     "The result of clipping is again a DataArray, this time though it is 40x40. We can plot this to see what it looks like, and to see the distribution of temperatures in the area."
@@ -968,7 +966,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eleven-participant",
+   "id": "hairy-canon",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,7 +1015,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "wooden-mobile",
+   "id": "mechanical-sarah",
    "metadata": {},
    "source": [
     ":::{admonition} What do these plots tell us about the surface temperature around the snow pit as measured by the airborne IR cameras?\n",
@@ -1033,7 +1031,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "moving-rouge",
+   "id": "bizarre-murder",
    "metadata": {},
    "source": [
     "**Plot the airborne IR temperature data on top of the ground-based timeseries**"
@@ -1042,7 +1040,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "excellent-cradle",
+   "id": "future-legend",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1082,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "helpful-copper",
+   "id": "worst-cambodia",
    "metadata": {},
    "source": [
     ":::{admonition} Continuing with this analysis:\n",
@@ -1098,7 +1096,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "statewide-blond",
+   "id": "afraid-monday",
    "metadata": {},
    "source": [
     "---\n",
@@ -1122,7 +1120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "editorial-chicago",
+   "id": "retained-eclipse",
    "metadata": {},
    "source": [
     "Load an ASTER geotiff that we've downloaded for this tutorial, and inspect its contents."
@@ -1131,7 +1129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "constitutional-globe",
+   "id": "usual-service",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,7 +1138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "standing-spell",
+   "id": "judicial-recorder",
    "metadata": {},
    "source": [
     "Inspect the ASTER file we just opened"
@@ -1149,7 +1147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "functioning-minimum",
+   "id": "familiar-hands",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1158,7 +1156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "shared-register",
+   "id": "durable-organic",
    "metadata": {},
    "source": [
     "What is its CRS?"
@@ -1167,7 +1165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "quality-labor",
+   "id": "descending-optics",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1177,7 +1175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lyric-vegetable",
+   "id": "apparent-creek",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1187,7 +1185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "super-springer",
+   "id": "studied-smith",
    "metadata": {},
    "source": [
     "When was this image taken?"
@@ -1196,7 +1194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "collect-honduras",
+   "id": "german-designer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1205,7 +1203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "about-michael",
+   "id": "future-jacksonville",
    "metadata": {},
    "source": [
     "Plot the image. What are the units of the values on the colorbar?"
@@ -1214,7 +1212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "occasional-picture",
+   "id": "raised-federation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1223,7 +1221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fifteen-utilization",
+   "id": "historic-pierre",
    "metadata": {},
    "source": [
     "It's necessary to read the product documentation to understand what we are looking at here. \n",
@@ -1238,7 +1236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "extended-korea",
+   "id": "challenging-angel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1258,7 +1256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "judicial-variance",
+   "id": "conventional-weekend",
    "metadata": {},
    "source": [
     "Use the above functions to convert from DN to radiance, radiance to brightness temperature (assume and emissivity of 1 for all surfaces, note that the airborne imagery also assumed emissivity of 1).\n",
@@ -1269,7 +1267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "scheduled-regular",
+   "id": "stretch-replication",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1283,7 +1281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abstract-edition",
+   "id": "buried-desert",
    "metadata": {},
    "source": [
     "During this unit conversion, xarray dropped the coordinate reference system attributes, so here we add the original crs to the new ASTER degrees celsius dataarray."
@@ -1292,7 +1290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "abandoned-perspective",
+   "id": "korean-raise",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1301,7 +1299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unable-challenge",
+   "id": "demonstrated-lodging",
    "metadata": {},
    "source": [
     "Plot our image again, this time setting our colorscale and colorbar values. We should see \"realistic\" surface temperature values in degrees C now."
@@ -1310,7 +1308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "colonial-senate",
+   "id": "aggressive-avenue",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1324,7 +1322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "swiss-formula",
+   "id": "bored-business",
    "metadata": {},
    "source": [
     ":::{admonition} Image interpretation\n",
@@ -1337,7 +1335,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "different-constant",
+   "id": "freelance-hearing",
    "metadata": {},
    "source": [
     "-\n",
@@ -1349,7 +1347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "trained-upgrade",
+   "id": "mechanical-connectivity",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1388,7 +1386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "selected-employee",
+   "id": "integrated-tiger",
    "metadata": {},
    "source": [
     "Make another plot to zoom in on snow pit 2S10:"
@@ -1397,7 +1395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "secret-checklist",
+   "id": "mounted-going",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1437,7 +1435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "given-elevation",
+   "id": "simple-framework",
    "metadata": {},
    "source": [
     "Get the temperature of the ASTER pixel at the snow pit point using rioxarray [clip](https://corteva.github.io/rioxarray/stable/examples/clip_geom.html)."
@@ -1446,7 +1444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "searching-chaos",
+   "id": "bizarre-treaty",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1462,7 +1460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "written-yellow",
+   "id": "binary-white",
    "metadata": {},
    "source": [
     "How many ASTER pixels in the area did we select?\n",
@@ -1473,7 +1471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "three-falls",
+   "id": "standard-manor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1504,7 +1502,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "functioning-voice",
+   "id": "catholic-parallel",
    "metadata": {},
    "source": [
     "**Plot the ASTER IR temperature data on top of the ground-based timeseries and airborne IR temperature**"
@@ -1513,7 +1511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nearby-elimination",
+   "id": "atlantic-siemens",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1565,7 +1563,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "immediate-grant",
+   "id": "convinced-merit",
    "metadata": {},
    "source": [
     "---\n",
@@ -1583,7 +1581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "piano-ballet",
+   "id": "valuable-chapel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1592,7 +1590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "micro-convenience",
+   "id": "authentic-mexico",
    "metadata": {},
    "source": [
     "Preview the result. \n",
@@ -1602,7 +1600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "greatest-plant",
+   "id": "norwegian-caribbean",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1611,7 +1609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "tracked-momentum",
+   "id": "fewer-bennett",
    "metadata": {},
    "source": [
     "Plot the ASTER image, original airborne IR image, and resampled airborne IR image next to each other to visualize these spatial resolution differences."
@@ -1620,7 +1618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sporting-sacramento",
+   "id": "fitted-consistency",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1670,7 +1668,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "critical-raleigh",
+   "id": "fallen-scoop",
    "metadata": {},
    "source": [
     "Finally, compute the difference between the ASTER IR image and resampled airborne IR image, then plot the result:"
@@ -1679,7 +1677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "massive-little",
+   "id": "crazy-providence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1690,7 +1688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "arranged-klein",
+   "id": "satisfied-rolling",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1719,7 +1717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "demanding-holly",
+   "id": "emotional-connecticut",
    "metadata": {},
    "source": [
     "---\n",

--- a/book/tutorials/thermal-ir/thermal-ir-tutorial.ipynb
+++ b/book/tutorials/thermal-ir/thermal-ir-tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "actual-marketplace",
+   "id": "demonstrated-sweet",
    "metadata": {},
    "source": [
     "# Thermal Infrared Remote Sensing of Snow\n",
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "absent-supplement",
+   "id": "broken-singapore",
    "metadata": {},
    "source": [
     "**Download the sample datasets for this tutorial**\n",
@@ -30,16 +30,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "refined-first",
+   "id": "front-federal",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!aws s3 sync --quiet s3://snowex-data/tutorial-data/thermal-ir/ /tmp/thermal-ir/"
+    "#%%bash \n",
+    "\n",
+    "# Datasets used in this tutorial are accessed directly from their online repositories\n",
+    "# But we also made a copy on zenodo in case servers are down, etc:\n",
+    "\n",
+    "#cd /tmp\n",
+    "#wget -nc https://zenodo.org/record/RECORD_ID/files/snowex-hackweek/tutorial-data.zip -O tutorial-data.zip\n",
+    "#wget -nc https://zenodo.org/record/3600624/files/dshean/hma_mb_paper-v1.0.zip -O tutorial-data.zip\n",
+    "#unzip -n tutorial-data.zip\n",
+    "\n",
+    "# temporary equivalent\n",
+    "#aws s3 sync --quiet s3://snowex-data/zenodo-data/ /tmp/tutorial-data "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "secondary-issue",
+   "id": "empty-swing",
    "metadata": {},
    "source": [
     "**Import the packages we'll need for this tutorial**"
@@ -48,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "supported-inclusion",
+   "id": "incorrect-premises",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "personal-presentation",
+   "id": "distant-income",
    "metadata": {},
    "source": [
     "---\n",
@@ -91,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "spanish-triangle",
+   "id": "sized-plenty",
    "metadata": {},
    "source": [
     "Load IR image mosaic geotiff file"
@@ -100,16 +111,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fiscal-discipline",
+   "id": "musical-matthew",
    "metadata": {},
    "outputs": [],
    "source": [
-    "airborne_ir = xr.open_rasterio('/tmp/thermal-ir/SNOWEX2020_IR_PLANE_2020Feb08_mosaicked_2020-02-08T181915.tif')"
+    "TUTORIAL_DATA = '/tmp/tutorial-data/thermal-ir/'\n",
+    "airborne_ir = xr.open_rasterio(f'{TUTORIAL_DATA}/SNOWEX2020_IR_PLANE_2020Feb08_mosaicked_2020-02-08T181915.tif')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "emotional-focus",
+   "id": "boxed-plymouth",
    "metadata": {},
    "source": [
     "Inspect the contents of the file we just opened"
@@ -118,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "canadian-residence",
+   "id": "graphic-wrapping",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "polar-gateway",
+   "id": "regional-angel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fresh-divide",
+   "id": "stock-welsh",
    "metadata": {},
    "source": [
     "Under the dataarray's attributes we can see that we have a coordinate reference system already defined (crs) as [EPSG:32612](https://epsg.io/32612). We can also find this through `da.rio.crs`. \n",
@@ -148,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "strategic-danish",
+   "id": "suffering-surfing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "spread-hands",
+   "id": "alone-banking",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "radical-aging",
+   "id": "deluxe-visiting",
    "metadata": {},
    "source": [
     "Next, the filename shows us when this imagery was taken in UTC time, \"2020-02-08T181915\"\n",
@@ -178,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "quarterly-climb",
+   "id": "backed-concord",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "automated-plate",
+   "id": "future-anxiety",
    "metadata": {},
    "source": [
     "::::{admonition} What color scale should we use for temperature?\n",
@@ -209,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "interpreted-continent",
+   "id": "geological-immune",
    "metadata": {},
    "source": [
     "Plot the airborne TIR image. \n",
@@ -220,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "public-nursing",
+   "id": "ranging-lebanon",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "occasional-search",
+   "id": "confirmed-anthony",
    "metadata": {},
    "source": [
     ":::{admonition} Image interpretation\n",
@@ -258,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fabulous-prerequisite",
+   "id": "educated-integrity",
    "metadata": {},
    "source": [
     "## Bonus activity:\n",
@@ -268,11 +280,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "constant-repair",
+   "id": "continental-wallpaper",
    "metadata": {},
    "outputs": [],
    "source": [
-    "airborne_vis = xr.open_rasterio('/tmp/thermal-ir/SNOWEX2020_EO_PLANE_2020Feb08_mosaicked_2020-02-08T181915.tif')\n",
+    "airborne_vis = xr.open_rasterio(f'{TUTORIAL_DATA}/SNOWEX2020_EO_PLANE_2020Feb08_mosaicked_2020-02-08T181915.tif')\n",
     "\n",
     "# note that the filename is identical with the same timestamp, but is labeled \"EO\" (electro-optical) rather than \"IR\" (infrared)"
    ]
@@ -280,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "impressed-renewal",
+   "id": "right-federal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "postal-vehicle",
+   "id": "interim-covering",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mexican-river",
+   "id": "educational-recommendation",
    "metadata": {},
    "source": [
     "Plot the visible and infrared images side by side. This time, we will change the x and y axes limits ([set_xlim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlim.html), and [set_ylim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_ylim.html)) to zoom in closer."
@@ -309,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "prompt-dylan",
+   "id": "czech-fiber",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "olive-treatment",
+   "id": "closing-publisher",
    "metadata": {},
    "source": [
     ":::{admonition} Image interpretation\n",
@@ -355,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lined-hamilton",
+   "id": "municipal-television",
    "metadata": {},
    "source": [
     "---\n",
@@ -388,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "neural-cabin",
+   "id": "contrary-authorization",
    "metadata": {},
    "source": [
     "**Where is snow pit 2S10?**\n",
@@ -399,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fresh-accent",
+   "id": "satellite-collins",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "violent-religious",
+   "id": "chubby-browser",
    "metadata": {},
    "source": [
     "Then, query [SiteData](https://snowexsql.readthedocs.io/en/latest/database_structure.html#sites-table) using [filter_by](https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.filter_by) to find the entry with the site ID that we want (2S10). Preview the resulting geodataframe."
@@ -420,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dedicated-folder",
+   "id": "angry-stroke",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "corporate-queensland",
+   "id": "willing-beast",
    "metadata": {},
    "source": [
     "Inspect of the geodatframe's metadata"
@@ -445,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "informative-vehicle",
+   "id": "nominated-system",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "occupied-gates",
+   "id": "positive-stuff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "considered-kentucky",
+   "id": "light-easter",
    "metadata": {},
    "source": [
     "We can now plot our snow pit site from this [geodataframe](https://geopandas.org/docs/reference/api/geopandas.GeoDataFrame.plot.html) on top of the airborne IR image. (See more tips about plotting geodataframes [here](https://www.earthdatascience.org/courses/scientists-guide-to-plotting-data-in-python/plot-spatial-data/customize-vector-plots/python-change-spatial-extent-of-map-matplotlib-geopandas/))\n",
@@ -476,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "extensive-inside",
+   "id": "lovely-russell",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +516,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "satellite-heritage",
+   "id": "sexual-request",
    "metadata": {},
    "source": [
     "Change the x and y axes limits ([set_xlim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlim.html), and [set_ylim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_ylim.html)) to zoom in to our point of interest. In this case we can use [df.geometry.total_bounds](https://geopandas.readthedocs.io/en/latest/docs/reference/api/geopandas.GeoSeries.total_bounds.html) to get the x and y values that define the area our geometry takes up. (In this case we have a point so it will return just the point's location, but this would work if we had a polygon as well)"
@@ -513,7 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "surprising-gather",
+   "id": "standard-capitol",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "inclusive-calibration",
+   "id": "proprietary-trading",
    "metadata": {},
    "source": [
     "**Import the snow temperature timeseries dataset**\n",
@@ -555,16 +567,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "retained-bleeding",
+   "id": "thorough-camping",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cat /tmp/thermal-ir/SNEX20_VPTS_Raw/Level-0/snow-temperature-timeseries/README.txt"
+    "!cat {TUTORIAL_DATA}/SNEX20_VPTS_Raw/Level-0/snow-temperature-timeseries/README.txt"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "center-boundary",
+   "id": "intensive-simple",
    "metadata": {},
    "source": [
     "Create a list of column headers according to the readme above (for \"GM1\" which we can read was the datalogger at snowpit 2S10)"
@@ -573,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "understood-lithuania",
+   "id": "median-civilization",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vanilla-import",
+   "id": "greek-craps",
    "metadata": {},
    "source": [
     "Open the file as a pandas data frame with [read_csv](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html)"
@@ -600,11 +612,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "oriented-legislation",
+   "id": "universal-auckland",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_csv('/tmp/thermal-ir/SNEX20_VPTS_Raw/Level-0/snow-temperature-timeseries/CR10X_GM1_final_storage_1.dat',\n",
+    "df = pd.read_csv(f'{TUTORIAL_DATA}/SNEX20_VPTS_Raw/Level-0/snow-temperature-timeseries/CR10X_GM1_final_storage_1.dat',\n",
     "                 header = None, names = column_headers) \n",
     "\n",
     "# After the filepath we specify header=None because the file doesn't contain column headers, \n",
@@ -613,7 +625,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fabulous-peeing",
+   "id": "educated-control",
    "metadata": {},
    "source": [
     "We need to do some formatting of the data fields, but we can preview what we just loaded fist"
@@ -622,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "anticipated-xerox",
+   "id": "altered-durham",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "competent-glenn",
+   "id": "adjacent-small",
    "metadata": {},
    "source": [
     "Data cleanup and formatting"
@@ -640,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "opposite-exclusive",
+   "id": "voluntary-isaac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,7 +669,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hearing-twins",
+   "id": "signal-integration",
    "metadata": {},
    "source": [
     "This function lets us convert year and day of year (the format that the datalogger uses) to a pandas [datetime index](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DatetimeIndex.html):"
@@ -666,7 +678,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "chronic-vampire",
+   "id": "blocked-timing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,7 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "insured-ratio",
+   "id": "approved-socket",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "peripheral-throat",
+   "id": "confident-astrology",
    "metadata": {},
    "source": [
     "Inspect the contents"
@@ -716,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sensitive-metro",
+   "id": "automotive-combining",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +737,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "needed-constitutional",
+   "id": "great-inflation",
    "metadata": {},
    "source": [
     "Make a simple plot of the data. We are interested in the variable `rad_avg` which is the average temperature measured by the radiometer over each 5 minute period."
@@ -734,7 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acoustic-spanish",
+   "id": "native-ranking",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,7 +776,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "indoor-iraqi",
+   "id": "fifth-tournament",
    "metadata": {},
    "source": [
     ":::{admonition} Bonus plot: look at snow temperatures below the snow surface\n",
@@ -786,7 +798,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "first-bottom",
+   "id": "stuffed-registrar",
    "metadata": {},
    "source": [
     "But then we want to focus on the date/time when our IR image was from, so zoom in on Feb 8th by changing our plot's [xlim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlim.html) (using pandas [Timestamps](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html) for the x axis values).\n"
@@ -795,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "expanded-clear",
+   "id": "particular-victim",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -824,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "excess-reach",
+   "id": "occasional-howard",
    "metadata": {},
    "source": [
     "---\n",
@@ -839,7 +851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "voluntary-province",
+   "id": "together-baking",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +864,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "medical-tampa",
+   "id": "extreme-frank",
    "metadata": {},
    "source": [
     "Our result is a DataArray with a single data value at one set of x and y coordinates.\n",
@@ -870,7 +882,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "celtic-imperial",
+   "id": "descending-firmware",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -885,7 +897,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mature-sphere",
+   "id": "brilliant-lincoln",
    "metadata": {},
    "source": [
     "What does this polygon look like when we plot it on top of the airborne IR image now?"
@@ -894,7 +906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "armed-research",
+   "id": "latter-syntax",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,7 +937,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mature-adams",
+   "id": "statistical-shoot",
    "metadata": {},
    "source": [
     "Clip the airborne IR raster again, now with our 200 m diameter polygon around the snow pit site."
@@ -934,7 +946,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cutting-lotus",
+   "id": "practical-candy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,7 +959,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "imperial-phoenix",
+   "id": "confident-settlement",
    "metadata": {},
    "source": [
     "The result of clipping is again a DataArray, this time though it is 40x40. We can plot this to see what it looks like, and to see the distribution of temperatures in the area."
@@ -956,7 +968,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "offensive-basketball",
+   "id": "eleven-participant",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +1017,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "thousand-thinking",
+   "id": "wooden-mobile",
    "metadata": {},
    "source": [
     ":::{admonition} What do these plots tell us about the surface temperature around the snow pit as measured by the airborne IR cameras?\n",
@@ -1021,7 +1033,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "former-billion",
+   "id": "moving-rouge",
    "metadata": {},
    "source": [
     "**Plot the airborne IR temperature data on top of the ground-based timeseries**"
@@ -1030,7 +1042,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "convertible-aggregate",
+   "id": "excellent-cradle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1072,7 +1084,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "impossible-navigation",
+   "id": "helpful-copper",
    "metadata": {},
    "source": [
     ":::{admonition} Continuing with this analysis:\n",
@@ -1086,7 +1098,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "academic-victory",
+   "id": "statewide-blond",
    "metadata": {},
    "source": [
     "---\n",
@@ -1110,7 +1122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "german-hayes",
+   "id": "editorial-chicago",
    "metadata": {},
    "source": [
     "Load an ASTER geotiff that we've downloaded for this tutorial, and inspect its contents."
@@ -1119,16 +1131,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mexican-retreat",
+   "id": "constitutional-globe",
    "metadata": {},
    "outputs": [],
    "source": [
-    "aster_ir = xr.open_rasterio('/tmp/thermal-ir/AST_L1T_00302082020180748_20200209065849_17218_ImageData14.tif')"
+    "aster_ir = xr.open_rasterio(f'{TUTORIAL_DATA}/AST_L1T_00302082020180748_20200209065849_17218_ImageData14.tif')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "collective-blank",
+   "id": "standing-spell",
    "metadata": {},
    "source": [
     "Inspect the ASTER file we just opened"
@@ -1137,7 +1149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "specified-concentrate",
+   "id": "functioning-minimum",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "therapeutic-environment",
+   "id": "shared-register",
    "metadata": {},
    "source": [
     "What is its CRS?"
@@ -1155,7 +1167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "decent-macro",
+   "id": "quality-labor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1165,7 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "arabic-softball",
+   "id": "lyric-vegetable",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1175,7 +1187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adverse-garbage",
+   "id": "super-springer",
    "metadata": {},
    "source": [
     "When was this image taken?"
@@ -1184,7 +1196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "plain-coalition",
+   "id": "collect-honduras",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1193,7 +1205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "congressional-monroe",
+   "id": "about-michael",
    "metadata": {},
    "source": [
     "Plot the image. What are the units of the values on the colorbar?"
@@ -1202,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "historical-kinase",
+   "id": "occasional-picture",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1211,7 +1223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "elect-circumstances",
+   "id": "fifteen-utilization",
    "metadata": {},
    "source": [
     "It's necessary to read the product documentation to understand what we are looking at here. \n",
@@ -1226,7 +1238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "continent-frequency",
+   "id": "extended-korea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1246,7 +1258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dress-trade",
+   "id": "judicial-variance",
    "metadata": {},
    "source": [
     "Use the above functions to convert from DN to radiance, radiance to brightness temperature (assume and emissivity of 1 for all surfaces, note that the airborne imagery also assumed emissivity of 1).\n",
@@ -1257,7 +1269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "processed-hartford",
+   "id": "scheduled-regular",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1271,7 +1283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "defined-thanksgiving",
+   "id": "abstract-edition",
    "metadata": {},
    "source": [
     "During this unit conversion, xarray dropped the coordinate reference system attributes, so here we add the original crs to the new ASTER degrees celsius dataarray."
@@ -1280,7 +1292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "consolidated-visiting",
+   "id": "abandoned-perspective",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1289,7 +1301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "coordinate-tracy",
+   "id": "unable-challenge",
    "metadata": {},
    "source": [
     "Plot our image again, this time setting our colorscale and colorbar values. We should see \"realistic\" surface temperature values in degrees C now."
@@ -1298,7 +1310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "progressive-momentum",
+   "id": "colonial-senate",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1312,7 +1324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "functional-composite",
+   "id": "swiss-formula",
    "metadata": {},
    "source": [
     ":::{admonition} Image interpretation\n",
@@ -1325,7 +1337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "married-kentucky",
+   "id": "different-constant",
    "metadata": {},
    "source": [
     "-\n",
@@ -1337,7 +1349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "auburn-pleasure",
+   "id": "trained-upgrade",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1376,7 +1388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "casual-clothing",
+   "id": "selected-employee",
    "metadata": {},
    "source": [
     "Make another plot to zoom in on snow pit 2S10:"
@@ -1385,7 +1397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "industrial-telephone",
+   "id": "secret-checklist",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1425,7 +1437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "allied-philadelphia",
+   "id": "given-elevation",
    "metadata": {},
    "source": [
     "Get the temperature of the ASTER pixel at the snow pit point using rioxarray [clip](https://corteva.github.io/rioxarray/stable/examples/clip_geom.html)."
@@ -1434,7 +1446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bored-patrick",
+   "id": "searching-chaos",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1450,7 +1462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adapted-delta",
+   "id": "written-yellow",
    "metadata": {},
    "source": [
     "How many ASTER pixels in the area did we select?\n",
@@ -1461,7 +1473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "legitimate-yield",
+   "id": "three-falls",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1492,7 +1504,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "english-gardening",
+   "id": "functioning-voice",
    "metadata": {},
    "source": [
     "**Plot the ASTER IR temperature data on top of the ground-based timeseries and airborne IR temperature**"
@@ -1501,7 +1513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bound-hebrew",
+   "id": "nearby-elimination",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1553,7 +1565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "creative-playlist",
+   "id": "immediate-grant",
    "metadata": {},
    "source": [
     "---\n",
@@ -1571,7 +1583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "patient-ethernet",
+   "id": "piano-ballet",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1580,7 +1592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "proved-longitude",
+   "id": "micro-convenience",
    "metadata": {},
    "source": [
     "Preview the result. \n",
@@ -1590,7 +1602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "joint-terrace",
+   "id": "greatest-plant",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1599,7 +1611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "statewide-amateur",
+   "id": "tracked-momentum",
    "metadata": {},
    "source": [
     "Plot the ASTER image, original airborne IR image, and resampled airborne IR image next to each other to visualize these spatial resolution differences."
@@ -1608,7 +1620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "later-midnight",
+   "id": "sporting-sacramento",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1658,7 +1670,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "political-essex",
+   "id": "critical-raleigh",
    "metadata": {},
    "source": [
     "Finally, compute the difference between the ASTER IR image and resampled airborne IR image, then plot the result:"
@@ -1667,7 +1679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "impaired-chick",
+   "id": "massive-little",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1678,7 +1690,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "delayed-pocket",
+   "id": "arranged-klein",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1707,7 +1719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "instrumental-apparel",
+   "id": "demanding-holly",
    "metadata": {},
    "source": [
     "---\n",
@@ -1747,14 +1759,6 @@
     "* [Validating ASTER Thermal Infrared Imaging for use in Snow Models](https://github.com/UW-GDA/aster-thermal/)\n",
     ":::"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "potential-bahrain",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
closes #15

* moved tutorial datasets from s3://snowex-data to https://zenodo.org/record/5504396
* updated tutorial notebooks to load data from zenodo instead of s3