### PR TITLE
pin docker image

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '0 0 * * 0'
 
 env:
-  DOCKER_IMAGE: uwhackweek/snowex:latest
+  DOCKER_IMAGE: uwhackweek/snowex:2021.09.07
 
 jobs:
   build-and-test:
@@ -27,7 +27,7 @@ jobs:
       run: |
         docker pull $DOCKER_IMAGE
         docker images
-    
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -47,7 +47,7 @@ jobs:
         -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
         -v ${{ github.workspace }}:/home/jovyan:rw \
         $DOCKER_IMAGE .github/workflows/build.sh
-    
+
     - name: Save Build
       if: ${{ always() }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -5,7 +5,7 @@ on: workflow_dispatch
     # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-workflow-configuration
 
 env:
-  DOCKER_IMAGE: uwhackweek/snowex:latest
+  DOCKER_IMAGE: uwhackweek/snowex:2021.09.07
 
 jobs:
   build-and-test:
@@ -13,12 +13,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    
+
     - name: Pull Docker Image
       run: |
         docker pull $DOCKER_IMAGE
         docker images
-    
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -38,7 +38,7 @@ jobs:
         -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
         -v ${{ github.workspace }}:/home/jovyan:rw \
         $DOCKER_IMAGE .github/workflows/build.sh
-    
+
     - name: Save Build
       if: ${{ always() }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/netlifypreview.yaml
+++ b/.github/workflows/netlifypreview.yaml
@@ -5,7 +5,7 @@ on:
     types: [labeled, synchronize]
 
 env:
-  DOCKER_IMAGE: uwhackweek/snowex:latest
+  DOCKER_IMAGE: uwhackweek/snowex:2021.09.07
 
 jobs:
   add-preview:

--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  DOCKER_IMAGE: uwhackweek/snowex:latest
+  DOCKER_IMAGE: uwhackweek/snowex:2021.09.07
 
 jobs:
   quality-control:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  DOCKER_IMAGE: uwhackweek/snowex:latest
+  DOCKER_IMAGE: uwhackweek/snowex:2021.09.07
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To add a tutorial as a jupyter notebook under [./book/tutorials](./book/tutorial
 ```
 git clone https://github.com/snowex-hackweek/website
 cd website
-docker run uwhackweek/snowex:latest -v $PWD:/home/jovyan jb build book
+docker run uwhackweek/snowex:2021.09.07 -v $PWD:/home/jovyan jb build book
 ```
 
 ## About JupyterBook

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   jupyterlab:
-    image: "uwhackweek/snowex:latest"
+    image: "uwhackweek/snowex:2021.09.07"
     ports:
       - "8888:8888"
     command: "jupyter lab --ip 0.0.0.0 --no-browser"


### PR DESCRIPTION
replace 'latest' with '2021.09.07', which has all the python libraries needed to run tutorials

final steps to get a zenodo release for the repository (addresses #151)